### PR TITLE
Fix performance bug in set_data_items / table modifications

### DIFF
--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -90,13 +90,10 @@ class SignalsTable(QTableWidget):
 
         self._data_items: Dict[str, QColor] = {}
 
-    def _clear_table(self) -> None:
-        pass
-
     def set_data_items(self, new_data_items: List[Tuple[str, QColor]]) -> None:
         self._data_items = {data_name: color for data_name, color in new_data_items}
-        self._clear_table()
 
+        self.setRowCount(0)  # clear the existing table, other resizing becomes really expensive
         self.setRowCount(len(self._data_items))  # create new items
         for row, (name, color) in enumerate(self._data_items.items()):
             for col in range(self.COL_COUNT):


### PR DESCRIPTION
Fix Qt table performance bug where changing items on a table with resize-to-contents columns is really slow. This now purges the table first before making changes.