### PR TITLE
Watch and refresh CSV, change loads to happen in same window

### DIFF
--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -261,6 +261,8 @@ class CsvLoaderPlotsTableWidget(PlotsTableWidget):
         for csv_filename, curr_data_items in csv_data_items.items():
             if csv_filename not in self._csv_time:  # skip files where the load time is unknown
                 continue
+            if not os.path.exists(csv_filename):  # ignore transiently missing files
+                continue
             csv_load_time, csv_modify_time, csv_stable_count = self._csv_time[csv_filename]
             new_modify_time = os.path.getmtime(csv_filename)
             if new_modify_time <= csv_load_time:

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -19,8 +19,18 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pyqtgraph as pg
-from PySide6.QtGui import QAction, QColor
-from PySide6.QtWidgets import QWidget, QPushButton, QFileDialog, QMenu, QVBoxLayout, QInputDialog, QLineEdit
+from PySide6 import QtWidgets
+from PySide6.QtGui import QAction, QColor, Qt
+from PySide6.QtWidgets import (
+    QWidget,
+    QPushButton,
+    QFileDialog,
+    QMenu,
+    QVBoxLayout,
+    QInputDialog,
+    QLineEdit,
+    QToolButton,
+)
 
 from ..time_axis import TimeAxisItem
 from ..multi_plot_widget import MultiPlotWidget
@@ -169,8 +179,21 @@ class CsvLoaderPlotsTableWidget(PlotsTableWidget):
     def _make_controls(self) -> QWidget:
         button_load = QPushButton("Load CSV")
         button_load.clicked.connect(self._on_load_csv)
-        button_append = QPushButton("Append CSV")
+        button_append = QToolButton()
+        button_append.setText("Append CSV")
+        button_append.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        button_append.setSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Fixed)
         button_append.clicked.connect(self._on_append_csv)
+        menu_append = QMenu(self)
+        action_refresh = QAction(menu_append)
+        action_refresh.setText("Refresh CSV")
+        menu_append.addAction(action_refresh)
+        action_watch = QAction(menu_append)
+        action_watch.setText("Set Watch")
+        menu_append.addAction(action_watch)
+        button_append.setPopupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
+        button_append.setArrowType(Qt.ArrowType.DownArrow)
+        button_append.setMenu(menu_append)
 
         button_visuals = QPushButton("Visual Settings")
         button_menu = QMenu(self)

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -38,6 +38,8 @@ from ..util import int_color
 class CsvLoaderPlotsTableWidget(PlotsTableWidget):
     """Example app-level widget that loads CSV files into the plotter"""
 
+    WATCH_INTERVAL_MS = 200  # polls the filesystem metadata for changes this frequently
+
     class Plots(PlotsTableWidget.PlotsTableMultiPlots):
         """Adds legend add functionality"""
 
@@ -187,10 +189,11 @@ class CsvLoaderPlotsTableWidget(PlotsTableWidget):
         action_refresh.triggered.connect(self._on_refresh_csv)
         self.addAction(action_refresh)
         menu_append.addAction(action_refresh)
-        action_watch = QAction(menu_append)
-        action_watch.setText("Set Watch")
-        action_watch.triggered.connect(self._on_set_watch)
-        menu_append.addAction(action_watch)
+        self._action_watch = QAction(menu_append)
+        self._action_watch.setText("Set Watch")
+        self._action_watch.setCheckable(True)
+        self._action_watch.toggled.connect(self._on_toggle_watch)
+        menu_append.addAction(self._action_watch)
         button_append.setPopupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
         button_append.setArrowType(Qt.ArrowType.DownArrow)
         button_append.setMenu(menu_append)
@@ -236,7 +239,11 @@ class CsvLoaderPlotsTableWidget(PlotsTableWidget):
         for csv_filename, curr_data_items in csv_data_items.items():
             self._load_csv(csv_filename, colnames=curr_data_items, append=True)  # nonew, colnames
 
-    def _on_set_watch(self) -> None:
+    def _on_toggle_watch(self) -> None:
+        if self._action_watch.isChecked():
+            pass
+        else:
+            pass
         raise NotImplementedError  # TODO IMPLEMENT ME
 
     def _load_csv(

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -38,7 +38,7 @@ from ..util import int_color
 class CsvLoaderPlotsTableWidget(PlotsTableWidget):
     """Example app-level widget that loads CSV files into the plotter"""
 
-    WATCH_INTERVAL_MS = 200  # polls the filesystem metadata for changes this frequently
+    WATCH_INTERVAL_MS = 250  # polls the filesystem metadata for changes this frequently
 
     class Plots(PlotsTableWidget.PlotsTableMultiPlots):
         """Adds legend add functionality"""

--- a/tests/test_csv_viewer.py
+++ b/tests/test_csv_viewer.py
@@ -45,10 +45,9 @@ def test_load_sparse_csv(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
 def test_watch_stability(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
     plot._load_csv(os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv"))
     qtbot.waitUntil(lambda: plot._plots.count() == 3)
-    with (
-        mock.patch.object(CsvLoaderPlotsTableWidget, "_load_csv") as mock_load_csv,
-        mock.patch.object(os.path, "getmtime") as mock_getmtime,
-    ):
+    with mock.patch.object(CsvLoaderPlotsTableWidget, "_load_csv") as mock_load_csv, mock.patch.object(
+        os.path, "getmtime"
+    ) as mock_getmtime:
         mock_getmtime.return_value = time.time() + 10
         plot._watch_timer.timeout.emit()
         mock_load_csv.assert_not_called()

--- a/tests/test_csv_viewer.py
+++ b/tests/test_csv_viewer.py
@@ -13,6 +13,8 @@
 #    limitations under the License.
 
 import os
+import time
+from unittest import mock
 
 import pytest
 from pytestqt.qtbot import QtBot
@@ -31,10 +33,37 @@ def plot(qtbot: QtBot) -> CsvLoaderPlotsTableWidget:
 
 
 def test_load_mixed_csv(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
-    new_plot = plot._load_csv(os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv"))
-    qtbot.waitUntil(lambda: new_plot._plots.count() == 3)  # just make sure it loads
+    plot._load_csv(os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv"))
+    qtbot.waitUntil(lambda: plot._plots.count() == 3)  # just make sure it loads
 
 
 def test_load_sparse_csv(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
-    new_plot = plot._load_csv(os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data_sparse.csv"))
-    qtbot.waitUntil(lambda: new_plot._plots.count() == 3)  # just make sure it loads
+    plot._load_csv(os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data_sparse.csv"))
+    qtbot.waitUntil(lambda: plot._plots.count() == 3)  # just make sure it loads
+
+
+def test_watch_stability(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
+    plot._load_csv(os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv"))
+    qtbot.waitUntil(lambda: plot._plots.count() == 3)
+    with (
+        mock.patch.object(CsvLoaderPlotsTableWidget, "_load_csv") as mock_load_csv,
+        mock.patch.object(os.path, "getmtime") as mock_getmtime,
+    ):
+        mock_getmtime.return_value = time.time() + 10
+        plot._watch_timer.timeout.emit()
+        mock_load_csv.assert_not_called()
+        plot._watch_timer.timeout.emit()
+        mock_load_csv.assert_not_called()
+        plot._watch_timer.timeout.emit()
+
+        mock_getmtime.return_value = mock_getmtime.return_value + 10  # reset the counter
+        plot._watch_timer.timeout.emit()
+        mock_load_csv.assert_not_called()
+        plot._watch_timer.timeout.emit()
+        mock_load_csv.assert_not_called()
+        plot._watch_timer.timeout.emit()
+        mock_load_csv.assert_not_called()
+        qtbot.wait(10)  # add a delay for the call to happen just in case
+        mock_load_csv.assert_not_called()
+        plot._watch_timer.timeout.emit()
+        qtbot.waitUntil(lambda: mock_load_csv.called)  # check the load happens


### PR DESCRIPTION
Add a button-menu action to refresh a CSV, add a button-menu checkbox to watch and auto-refresh loaded CSVs.

Changes the code to no longer open a new window on loading / appending CSVs, instead changing the visualization in-place. Add x-axis changing code to the MultiPlotWidget infrastructure which handles change consistency.
