### PR TITLE
General performance improvements

### DIFF
--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -350,8 +350,9 @@ class CsvLoaderPlotsTableWidget(PlotsTableWidget):
         if any_is_timevalue:
             self._plots.set_x_axis(lambda: TimeAxisItem(orientation="bottom"))
 
-        data_items = [(name, int_color(i), data_type) for i, (name, data_type) in enumerate(data_type_dict.items())]
-        self._set_data_items(data_items)
+        if colnames is None:  # colnames not None means update only
+            data_items = [(name, int_color(i), data_type) for i, (name, data_type) in enumerate(data_type_dict.items())]
+            self._set_data_items(data_items)
         self._set_data(data_dict)
         self._csv_data_items = csv_data_items_dict
 

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -342,7 +342,8 @@ class RegionPlot(SnappableHoverPlot):
                 self.cursor_range.sigRegionChanged.connect(self._on_region_drag)
                 self.addItem(self.cursor_range, ignoreBounds=True)
             self._last_cursor_range = region
-            self.cursor_range.setRegion(self._last_cursor_range)
+            with QSignalBlocker(self.cursor_range):
+                self.cursor_range.setRegion(self._last_cursor_range)
 
             self._update_cursor_labels()
             self.sigCursorRangeChanged.emit(self.cursor_range.getRegion())
@@ -354,7 +355,8 @@ class RegionPlot(SnappableHoverPlot):
                 self.cursor = pg.InfiniteLine(movable=True)
                 self.cursor.sigDragged.connect(self._on_cursor_drag)
                 self.addItem(self.cursor, ignoreBounds=True)
-            self.cursor.setPos(region)
+            with QSignalBlocker(self.cursor):
+                self.cursor.setPos(region)
 
             self._update_cursor_labels()
             self.sigCursorRangeChanged.emit(self.cursor.pos().x())

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -124,7 +124,7 @@ class StatsSignalsTable(SignalsTable):
     ]
 
     class StatsCalculatorSignals(QObject):
-        update = Signal(object, object, object)  # input array, opt indices, {stat (by offset col) -> value}
+        update = Signal(object, object, object)  # input array, region, {stat (by offset col) -> value}
 
     class StatsCalculatorThread(QThread):
         """Stats calculated in a separate thread to avoid blocking the main GUI thread when large regions

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -86,7 +86,7 @@ class SignalsTable(QTableWidget):
 
         header = self.horizontalHeader()
         for col in range(self.columnCount()):
-            header.setSectionResizeMode(col, QHeaderView.ResizeMode.ResizeToContents)
+            header.setSectionResizeMode(col, QHeaderView.ResizeMode.Interactive)
 
         self._data_items: Dict[str, QColor] = {}
 
@@ -191,7 +191,7 @@ class StatsSignalsTable(SignalsTable):
         thread = self.StatsCalculatorThread(self, needed_stats)
         thread.signals.update.connect(self._on_full_range_stats_updated)
         thread.finished.connect(thread.deleteLater)
-        thread.start()
+        thread.start(QThread.Priority.IdlePriority)
         self._update_stats()
 
     def set_range(self, range: Tuple[float, float]) -> None:

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -170,6 +170,10 @@ class StatsSignalsTable(SignalsTable):
                     stats_dict = self._calculate_stats(ys_region)
                     self.signals.update.emit(ys, task.region, stats_dict)
 
+        def terminate_wait(self) -> None:
+            self.terminate()
+            self.wait()  # needed otherwise pytest fails on Linux
+
         @classmethod
         def _calculate_stats(cls, ys: npt.NDArray[np.float64]) -> Dict[int, float]:
             """Calculates stats (as dict of col offset -> value) for the specified xs, ys.
@@ -208,7 +212,7 @@ class StatsSignalsTable(SignalsTable):
         self._stats_compute_thread = self.StatsCalculatorThread(self)
         self._stats_compute_thread.signals.update.connect(self._on_stats_updated)
         self._stats_compute_thread.start(QThread.Priority.IdlePriority)
-        self.destroyed.connect(lambda: self._stats_compute_thread.terminate())
+        self.destroyed.connect(lambda: self._stats_compute_thread.terminate_wait())
 
     def _on_stats_updated(
         self, input_arr: npt.NDArray[np.float64], region: Tuple[float, float], stats_dict: Dict[int, float]

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -143,7 +143,7 @@ class StatsSignalsTable(SignalsTable):
         def __init__(self, parent: Any):
             super().__init__(parent)
             self.signals = StatsSignalsTable.StatsCalculatorSignals()
-            self.queue = queue.Queue[self.Task]()
+            self.queue = queue.Queue[StatsSignalsTable.StatsCalculatorThread.Task]()
 
         def run(self) -> None:
             while True:


### PR DESCRIPTION
- Use QSignalBlocker to avoid duplicate region events
- Stats calculator: all stats now happens in a single separate thread, which takes tasks from a queue. New queue entries replace in-progress calculations. This deals with large regions better
- Stats calculator: compute thread is now lowest priority.
- Stats table: col sizes now interactive, changing values on a fixed table is really, really expensive
- CSV viewer: don't update data items when colnames specified
