### PR TITLE
X-Y plot option

### DIFF
--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -26,5 +26,6 @@ from .signals_table import DeleteableSignalsTable
 from .timeshift_signals_table import TimeshiftSignalsTable
 from .transforms_signal_table import TransformsSignalsTable
 from .search_signals_table import SearchSignalsTable
+from .xy_plot_table import XyTable
 
 from .time_axis import TimeAxisItem

--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -22,7 +22,13 @@ from .interactivity_mixins import (
 )
 from .enum_waveform_plotitem import EnumWaveformPlot
 from .plots_table_widget import PlotsTableWidget
-from .signals_table import DeleteableSignalsTable
+from .signals_table import (
+    DeleteableSignalsTable,
+    HasDataSignalsTable,
+    StatsSignalsTable,
+    ColorPickerSignalsTable,
+    DraggableSignalsTable,
+)
 from .timeshift_signals_table import TimeshiftSignalsTable
 from .transforms_signal_table import TransformsSignalsTable
 from .search_signals_table import SearchSignalsTable

--- a/pyqtgraph_scope_plots/csv/__main__.py
+++ b/pyqtgraph_scope_plots/csv/__main__.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     plots._set_data(
         {
             "sine": (xs, np.sin(xs / X_PER_CYCLE * 2 * math.pi)),
-            "square": (xs, np.signbit(np.sin(xs / X_PER_CYCLE * 2 * math.pi))),
+            "square": (xs, np.signbit(np.sin(xs / X_PER_CYCLE * 2 * math.pi)).astype(float)),
             "cycle": (
                 xs,
                 [f"Cycle {int(x)}" for x in np.floor(xs / X_PER_CYCLE)],

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -20,16 +20,17 @@ import numpy.typing as npt
 import pandas as pd
 import pyqtgraph as pg
 from PySide6.QtGui import QAction, QColor
-from PySide6.QtWidgets import QWidget, QPushButton, QFileDialog, QMenu, QVBoxLayout, QInputDialog, QLineEdit
+from PySide6.QtWidgets import QWidget, QPushButton, QFileDialog, QMenu, QVBoxLayout, QInputDialog
 
-from ..time_axis import TimeAxisItem
 from ..multi_plot_widget import MultiPlotWidget
 from ..plots_table_widget import PlotsTableWidget
 from ..search_signals_table import SearchSignalsTable
 from ..signals_table import ColorPickerSignalsTable, StatsSignalsTable
+from ..time_axis import TimeAxisItem
 from ..timeshift_signals_table import TimeshiftSignalsTable
 from ..transforms_signal_table import TransformsSignalsTable
 from ..util import int_color
+from ..xy_plot_table import XyTable
 
 
 class CsvLoaderPlotsTableWidget(PlotsTableWidget):
@@ -53,6 +54,7 @@ class CsvLoaderPlotsTableWidget(PlotsTableWidget):
             self._outer._apply_line_width()
 
     class CsvSignalsTable(
+        XyTable,
         ColorPickerSignalsTable,
         PlotsTableWidget.PlotsTableSignalsTable,
         TransformsSignalsTable,

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -35,7 +35,6 @@ from ..time_axis import TimeAxisItem
 from ..timeshift_signals_table import TimeshiftSignalsTable
 from ..transforms_signal_table import TransformsSignalsTable
 from ..util import int_color
-from ..xy_plot_table import XyTable
 
 
 class CsvLoaderPlotsTableWidget(PlotsTableWidget):
@@ -62,7 +61,6 @@ class CsvLoaderPlotsTableWidget(PlotsTableWidget):
             self._outer._apply_line_width()
 
     class CsvSignalsTable(
-        XyTable,
         ColorPickerSignalsTable,
         PlotsTableWidget.PlotsTableSignalsTable,
         TransformsSignalsTable,

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -104,9 +104,8 @@ class PlotsTableWidget(QSplitter):
         for data_name in data.keys():
             transformed = self._table.apply_transform(data_name, data)
             if isinstance(transformed, Exception):
-                pass
-            else:
-                transformed_data[data_name] = data[data_name][0], transformed
+                continue
+            transformed_data[data_name] = data[data_name][0], transformed
         return transformed_data
 
     def _set_data(

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -28,13 +28,14 @@ from .multi_plot_widget import (
 )
 from .signals_table import StatsSignalsTable, DraggableSignalsTable
 from .transforms_signal_table import TransformsSignalsTable
+from .xy_plot_table import XyTable
 
 
 class PlotsTableWidget(QSplitter):
     class PlotsTableMultiPlots(DroppableMultiPlotWidget, LinkedMultiPlotWidget):
         """MultiPlotWidget used in PlotsTableWidget with required mixins."""
 
-    class PlotsTableSignalsTable(DraggableSignalsTable, TransformsSignalsTable, StatsSignalsTable):
+    class PlotsTableSignalsTable(DraggableSignalsTable, XyTable, TransformsSignalsTable, StatsSignalsTable):
         """SignalsTable used in PlotsTableWidget with required mixins."""
 
         def __init__(self, plots: MultiPlotWidget, *args: Any, **kwargs: Any) -> None:

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -117,7 +117,7 @@ class HasRegionSignalsTable(SignalsTable):
     ) -> Tuple[Optional[int], Optional[int]]:
         """Given the x points and a region, return the indices of xs containing the region"""
         low_index = bisect.bisect_left(xs, region[0])  # inclusive
-        high_index = bisect.bisect_right(xs, region[1])  # inclusive
+        high_index = bisect.bisect_right(xs, region[1])  # exclusive
         if low_index >= high_index:  # empty set
             return None, None
         else:

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -106,7 +106,7 @@ class SignalsTable(QTableWidget):
 
 
 class HasRegionSignalsTable(SignalsTable):
-    """A SignalsTable that listens for a region change and provides some utiltiies"""
+    """A SignalsTable that listens for a region change and provides some utilities"""
 
     def set_range(self, range: Tuple[float, float]) -> None:
         self._range = range
@@ -135,7 +135,6 @@ class HasDataSignalsTable(SignalsTable):
         self,
         data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
     ) -> None:
-        """Sets the data and updates statistics"""
         self._data = data
 
 

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -105,7 +105,41 @@ class SignalsTable(QTableWidget):
             not_none(self.item(row, self.COL_NAME)).setText(name)
 
 
-class StatsSignalsTable(SignalsTable):
+class HasRegionSignalsTable(SignalsTable):
+    """A SignalsTable that listens for a region change and provides some utiltiies"""
+
+    def set_range(self, range: Tuple[float, float]) -> None:
+        self._range = range
+
+    @classmethod
+    def _indices_of_region(
+        cls, xs: npt.NDArray[np.float64], region: Tuple[float, float]
+    ) -> Tuple[Optional[int], Optional[int]]:
+        """Given the x points and a region, return the indices of xs containing the region"""
+        low_index = bisect.bisect_left(xs, region[0])  # inclusive
+        high_index = bisect.bisect_right(xs, region[1])  # inclusive
+        if low_index >= high_index:  # empty set
+            return None, None
+        else:
+            return low_index, high_index
+
+
+class HasDataSignalsTable(SignalsTable):
+    """A SignalsTable that stores a copy of the data"""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = {}
+
+    def set_data(
+        self,
+        data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
+    ) -> None:
+        """Sets the data and updates statistics"""
+        self._data = data
+
+
+class StatsSignalsTable(HasRegionSignalsTable, HasDataSignalsTable):
     """Mixin into SignalsTable with statistics rows. Optional range to specify computation of statistics.
     Values passed into set_data must all be numeric."""
 
@@ -161,9 +195,8 @@ class StatsSignalsTable(SignalsTable):
                     ys = xs_ys_ref[1]()
                     if xs is None or ys is None:  # skip objects that have been deleted
                         continue
-                    low_index = bisect.bisect_left(xs, task.region[0])  # inclusive
-                    high_index = bisect.bisect_right(xs, task.region[1])  # inclusive
-                    if low_index >= high_index:  # empty set
+                    low_index, high_index = HasRegionSignalsTable._indices_of_region(xs, task.region)
+                    if low_index is None or high_index is None:  # empty set
                         ys_region = np.array([])
                     else:
                         ys_region = ys[low_index:high_index]
@@ -203,7 +236,6 @@ class StatsSignalsTable(SignalsTable):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = {}
         # since calculating stats across the full range is VERY EXPENSIVE, cache the results
         self._full_range_stats = IdentityCacheDict[npt.NDArray[np.float64], Dict[int, float]]()  # array -> stats dict
         self._region_stats = IdentityCacheDict[npt.NDArray[np.float64], Dict[int, float]]()  # array -> stats dict
@@ -230,12 +262,12 @@ class StatsSignalsTable(SignalsTable):
         data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
     ) -> None:
         """Sets the data and updates statistics"""
-        self._data = data
+        super().set_data(data)
         self._create_stats_task()
         self._update_stats()
 
     def set_range(self, range: Tuple[float, float]) -> None:
-        self._range = range
+        super().set_range(range)
         self._create_stats_task()
         self._update_stats()
 

--- a/pyqtgraph_scope_plots/transforms_signal_table.py
+++ b/pyqtgraph_scope_plots/transforms_signal_table.py
@@ -115,7 +115,7 @@ class TransformsSignalsTable(ContextMenuSignalsTable):
                 new_y = self._simpleeval.eval(expr, parsed)
                 # note, float and int are technically different, but are same enough here
                 if not (isinstance(new_y, numbers.Number) and isinstance(y, numbers.Number)) and type(new_y) != type(y):
-                    raise TypeError
+                    raise TypeError(f"returned {new_y} of type {type(new_y)} != original type {type(y)}")
                 new_ys.append(new_y)
             except Exception as e:
                 data_name_to_row = {data_name: i for i, data_name in enumerate(self._data_items.keys())}

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -63,14 +63,14 @@ class XyPlotWidget(pg.PlotWidget):  # type: ignore[misc]
             x_xs, x_ys = data.get(x_name, (None, None))
             y_xs, y_ys = data.get(y_name, (None, None))
             if x_xs is None or x_ys is None or y_xs is None or y_ys is None:
-                return
+                continue
             x_lo, x_hi = HasRegionSignalsTable._indices_of_region(x_xs, self._region)
             y_lo, y_hi = HasRegionSignalsTable._indices_of_region(y_xs, self._region)
             if x_lo is None or x_hi is None or y_lo is None or y_hi is None or x_hi - x_lo < 2:
-                return  # empty plot
+                continue  # empty plot
             if not np.array_equal(x_xs[x_lo:x_hi], y_xs[x_lo:x_hi]):
                 print(f"X/Y indices of {x_name}, {y_name} do not match")
-                return
+                continue
 
             # PyQtGraph doesn't support native fade colors, so approximate with multiple segments
             y_color = self._parent._data_items.get(y_name, QColor("white"))

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-from functools import partial
+
 from typing import Any, List, Tuple, Mapping
 
 import numpy as np

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -62,26 +62,22 @@ class XyPlotWidget(pg.PlotWidget):  # type: ignore[misc]
         for x_name, y_name in self._xys:
             x_xs, x_ys = data.get(x_name, (None, None))
             y_xs, y_ys = data.get(y_name, (None, None))
-            y_color = self._parent._data_items.get(y_name, QColor("white"))
             if x_xs is None or x_ys is None or y_xs is None or y_ys is None:
                 return
             x_lo, x_hi = HasRegionSignalsTable._indices_of_region(x_xs, self._region)
-            y_lo, y_hi = HasRegionSignalsTable._indices_of_region(x_xs, self._region)
-            if x_lo is None or x_hi is None or y_lo is None or y_hi is None:
+            y_lo, y_hi = HasRegionSignalsTable._indices_of_region(y_xs, self._region)
+            if x_lo is None or x_hi is None or y_lo is None or y_hi is None or x_hi - x_lo < 2:
                 return  # empty plot
             if not np.array_equal(x_xs[x_lo:x_hi], y_xs[x_lo:x_hi]):
                 print(f"X/Y indices of {x_name}, {y_name} do not match")
                 return
-            if x_hi - x_lo < 2:
-                return
 
             # PyQtGraph doesn't support native fade colors, so approximate with multiple segments
+            y_color = self._parent._data_items.get(y_name, QColor("white"))
             fade_segments = min(self.FADE_SEGMENTS, x_hi - x_lo)
             last_segment_end = x_lo
-            segments = []
             for i in range(fade_segments):
                 this_end = int(i / (fade_segments - 1) * (x_hi - x_lo)) + x_lo
-                segments.append((last_segment_end, this_end))
                 curve = pg.PlotCurveItem(
                     x=x_ys[last_segment_end : this_end + 1], y=y_ys[last_segment_end : this_end + 1]
                 )

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -26,7 +26,7 @@ class XyPlotWidget(pg.PlotWidget):
         super().__init__()
 
     def add_xy(self):
-        
+        pass
 
 
 class XyTable(ContextMenuSignalsTable):

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -1,0 +1,37 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from typing import Any
+
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QWidget, QMenu
+
+from .signals_table import ContextMenuSignalsTable
+
+
+class XyTable(ContextMenuSignalsTable):
+    """Mixin into SignalsTable that adds the option to open an XY plot in a separate window."""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._xy_action = QAction("Create X-Y Plot", self)
+        self._xy_action.triggered.connect(self._on_xy)
+
+    def _populate_context_menu(self, menu: QMenu) -> None:
+        super()._populate_context_menu(menu)
+        menu.addAction(self._xy_action)
+
+    def _on_xy(self) -> QWidget:
+        """Creates an XY plot with the selected signal(s) and returns the new plot."""
+        pass

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -12,13 +12,20 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from typing import Any
+from typing import Any, List
 
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QWidget, QMenu
 import pyqtgraph as pg
 
 from .signals_table import ContextMenuSignalsTable
+
+
+class XyPlotWidget(pg.PlotWidget):
+    def __init__(
+        self,
+    ):
+        super().__init__()
 
 
 class XyTable(ContextMenuSignalsTable):
@@ -28,15 +35,15 @@ class XyTable(ContextMenuSignalsTable):
         super().__init__(*args, **kwargs)
         self._xy_action = QAction("Create X-Y Plot", self)
         self._xy_action.triggered.connect(self._on_xy)
-        self._xy_plots = []
+        self._xy_plots: List[XyPlotWidget] = []
 
     def _populate_context_menu(self, menu: QMenu) -> None:
         super()._populate_context_menu(menu)
         menu.addAction(self._xy_action)
 
-    def _on_xy(self) -> pg.PlotWidget:
+    def _on_xy(self) -> XyPlotWidget:
         """Creates an XY plot with the selected signal(s) and returns the new plot."""
-        plot = pg.PlotWidget()
+        plot = XyPlotWidget()
         plot.addItem(pg.PlotCurveItem(x=[0, 1, 2, 4], y=[4, 6, 8, 10]))
         plot.show()
         self._xy_plots.append(plot)  # need an active reference to prevent GC'ing

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -55,9 +55,8 @@ class XyPlotWidget(pg.PlotWidget):  # type: ignore[misc]
             for data_name in data.keys():
                 transformed = self._parent.apply_transform(data_name, data)
                 if isinstance(transformed, Exception):
-                    pass
-                else:
-                    transformed_data[data_name] = data[data_name][0], transformed
+                    continue
+                transformed_data[data_name] = data[data_name][0], transformed
             data = transformed_data
 
         for x_name, y_name in self._xys:

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QWidget, QMenu
+import pyqtgraph as pg
 
 from .signals_table import ContextMenuSignalsTable
 
@@ -27,11 +28,16 @@ class XyTable(ContextMenuSignalsTable):
         super().__init__(*args, **kwargs)
         self._xy_action = QAction("Create X-Y Plot", self)
         self._xy_action.triggered.connect(self._on_xy)
+        self._xy_plots = []
 
     def _populate_context_menu(self, menu: QMenu) -> None:
         super()._populate_context_menu(menu)
         menu.addAction(self._xy_action)
 
-    def _on_xy(self) -> QWidget:
+    def _on_xy(self) -> pg.PlotWidget:
         """Creates an XY plot with the selected signal(s) and returns the new plot."""
-        pass
+        plot = pg.PlotWidget()
+        plot.addItem(pg.PlotCurveItem(x=[0, 1, 2, 4], y=[4, 6, 8, 10]))
+        plot.show()
+        self._xy_plots.append(plot)  # need an active reference to prevent GC'ing
+        return plot

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -22,10 +22,11 @@ from .signals_table import ContextMenuSignalsTable
 
 
 class XyPlotWidget(pg.PlotWidget):
-    def __init__(
-        self,
-    ):
+    def __init__(self):
         super().__init__()
+
+    def add_xy(self):
+        
 
 
 class XyTable(ContextMenuSignalsTable):
@@ -44,7 +45,7 @@ class XyTable(ContextMenuSignalsTable):
     def _on_xy(self) -> XyPlotWidget:
         """Creates an XY plot with the selected signal(s) and returns the new plot."""
         plot = XyPlotWidget()
-        plot.addItem(pg.PlotCurveItem(x=[0, 1, 2, 4], y=[4, 6, 8, 10]))
+        plot.addItem(pg.PlotCurveItem(x=[0, 1, 2, 4, 2], y=[4, 6, 8, 10, 16]))
         plot.show()
         self._xy_plots.append(plot)  # need an active reference to prevent GC'ing
         return plot

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -47,9 +47,13 @@ class XyPlotWidget(pg.PlotWidget):  # type: ignore[misc]
             y_color = self._parent._data_items.get(y_name, QColor("white"))
             if x_xs is None or x_ys is None or y_xs is None or y_ys is None:
                 return
-            assert np.array_equal(x_xs, y_xs), "TODO support resampling"
+            x_lo, x_hi = HasRegionSignalsTable._indices_of_region(x_xs, self._region)
+            y_lo, y_hi = HasRegionSignalsTable._indices_of_region(x_xs, self._region)
+            if x_lo is None or x_hi is None or y_lo is None or y_hi is None:
+                return  # empty plot
+            assert np.array_equal(x_xs[x_lo:x_hi], y_xs[x_lo:x_hi]), "TODO support resampling"
 
-            curve = pg.PlotCurveItem(x=x_ys, y=y_ys)
+            curve = pg.PlotCurveItem(x=x_ys[x_lo:x_hi], y=y_ys[x_lo:x_hi])
             curve.setPen(color=y_color, width=1)
             self.addItem(curve)
 

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -21,8 +21,8 @@ from PySide6.QtGui import QAction, QColor
 from PySide6.QtWidgets import QMenu, QTableWidgetItem, QMessageBox
 from numpy import typing as npt
 
-from . import TransformsSignalsTable
 from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable
+from .transforms_signal_table import TransformsSignalsTable
 
 
 class XyPlotWidget(pg.PlotWidget):  # type: ignore[misc]
@@ -127,7 +127,7 @@ class XyTable(ContextMenuSignalsTable, HasRegionSignalsTable, HasDataSignalsTabl
         super().set_data(data)
         self._update_xys()
 
-    def _update_xys(self):
+    def _update_xys(self) -> None:
         for xy_plot in self._xy_plots:
             xy_plot.set_range(self._range)
 
@@ -146,5 +146,5 @@ class XyTable(ContextMenuSignalsTable, HasRegionSignalsTable, HasDataSignalsTabl
         xy_plot.add_xy(data[0], data[1])
         return xy_plot
 
-    def _on_closed_xy(self, closed: XyPlotWidget):
+    def _on_closed_xy(self, closed: XyPlotWidget) -> None:
         self._xy_plots = [plot for plot in self._xy_plots if plot is not closed]

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -1,0 +1,35 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from pytestqt.qtbot import QtBot
+
+from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
+from .test_base_plot import plot
+
+
+def test_xy_create(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    # test that xy creation doesn't error out and follows the user order
+    # use items 1 and 2 since they share the same indices
+    plot._table.item(2, 0).setSelected(True)
+    plot._table.item(1, 0).setSelected(True)
+    xy_plot = plot._table._on_xy()
+    assert xy_plot is not None
+    assert xy_plot._xys == [("2", "1")]
+
+    plot._table.clearSelection()
+    plot._table.item(1, 0).setSelected(True)
+    plot._table.item(2, 0).setSelected(True)
+    xy_plot = plot._table._on_xy()
+    assert xy_plot is not None
+    assert xy_plot._xys == [("1", "2")]


### PR DESCRIPTION
Add an X-Y plot option from a signal table mixin. X-Y ordering is specified by the order in which the signals are selected. X-Y line fades with older time / smaller index. Synchronized with regions, if active. Supports transforms.

Also fixes a datatype issue with the example waveform and improves transform error messages.

Adds a few base mixins HasRegionsSignalsTable and HasDataSignalsTable to deduplicate some shared code.