### PR TITLE
Create animated GIF from plots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ license = "Apache-2.0"
 dependencies = [
     "PySide6~=6.6",
     "pyqtgraph~=0.13",
+    "pillow>=9.0",
     "pandas~=2.0",
     "numpy>=1.19",
     "simpleeval==1.0.3",

--- a/pyqtgraph_scope_plots/animation_plot_table_widget.py
+++ b/pyqtgraph_scope_plots/animation_plot_table_widget.py
@@ -11,8 +11,8 @@ class AnimationPlotsTableWidget(PlotsTableWidget):
     FRAMES_PER_SEGMENT = 8  # TODO these should be user-configurable
     MS_PER_FRAME = 100
 
-    def _start_animation_ui_flow(self):
-        value, ok = QInputDialog().getDouble(
+    def _start_animation_ui_flow(self) -> None:
+        region_percentage, ok = QInputDialog().getDouble(
             self, "Animation", "Region percentage per frame", 10, minValue=0, maxValue=100
         )
         if not ok:
@@ -21,5 +21,24 @@ class AnimationPlotsTableWidget(PlotsTableWidget):
         if not filename:
             return
 
+        if isinstance(self._plots._last_region, tuple):
+            full_region = self._plots._last_region
+            restore_full_region = True
+        else:
+            all_xs = [data[0] for data in self._transformed_data.values()]
+            min_xs = [min(data) for data in all_xs if len(data)]
+            max_xs = [max(data) for data in all_xs if len(data)]
+            assert min_xs or max_xs, "no data to determine full region"
+            full_region = (min(min_xs), max(max_xs))
+            restore_full_region = False
+        assert full_region[1] > full_region[0], "empty region"
+
+        frames_count = self.FRAMES_PER_SEGMENT * (100 / region_percentage)
+
         with open(filename, "w", newline="") as f:
             pass
+
+        if restore_full_region:
+            self._plots._on_region_change(full_region, None)
+        else:
+            self._plots._on_region_change(None, None)

--- a/pyqtgraph_scope_plots/animation_plot_table_widget.py
+++ b/pyqtgraph_scope_plots/animation_plot_table_widget.py
@@ -1,0 +1,25 @@
+from PySide6.QtWidgets import QInputDialog, QFileDialog
+
+from .plots_table_widget import PlotsTableWidget
+
+
+class AnimationPlotsTableWidget(PlotsTableWidget):
+    """A PlotTableWidget that provides a function for generating an animation from the plot windows.
+    This function handles the UI flow for generating an animation, but does not provide the controls
+    to initiate this flow (which is left up to the subclass to implement)"""
+
+    FRAMES_PER_SEGMENT = 8  # TODO these should be user-configurable
+    MS_PER_FRAME = 100
+
+    def _start_animation_ui_flow(self):
+        value, ok = QInputDialog().getDouble(
+            self, "Animation", "Region percentage per frame", 10, minValue=0, maxValue=100
+        )
+        if not ok:
+            return
+        filename, filter = QFileDialog.getSaveFileName(self, f"Animation", "", "Animated GIF (*.gif)")
+        if not filename:
+            return
+
+        with open(filename, "w", newline="") as f:
+            pass

--- a/pyqtgraph_scope_plots/animation_plot_table_widget.py
+++ b/pyqtgraph_scope_plots/animation_plot_table_widget.py
@@ -1,4 +1,8 @@
-from PySide6.QtWidgets import QInputDialog, QFileDialog
+from typing import List
+
+from PySide6 import QtGui
+from PySide6.QtWidgets import QInputDialog, QFileDialog, QWidget
+from PIL import Image
 
 from .plots_table_widget import PlotsTableWidget
 
@@ -8,17 +12,14 @@ class AnimationPlotsTableWidget(PlotsTableWidget):
     This function handles the UI flow for generating an animation, but does not provide the controls
     to initiate this flow (which is left up to the subclass to implement)"""
 
-    FRAMES_PER_SEGMENT = 8  # TODO these should be user-configurable
-    MS_PER_FRAME = 100
+    FRAMES_PER_SEGMENT = 4  # TODO these should be user-configurable
+    MS_PER_FRAME = 50
 
-    def _start_animation_ui_flow(self) -> None:
+    def _start_animation_ui_flow(self, default_filename: str = "") -> None:
         region_percentage, ok = QInputDialog().getDouble(
             self, "Animation", "Region percentage per frame", 10, minValue=0, maxValue=100
         )
         if not ok:
-            return
-        filename, filter = QFileDialog.getSaveFileName(self, f"Animation", "", "Animated GIF (*.gif)")
-        if not filename:
             return
 
         if isinstance(self._plots._last_region, tuple):
@@ -33,15 +34,30 @@ class AnimationPlotsTableWidget(PlotsTableWidget):
             restore_full_region = False
         assert full_region[1] > full_region[0], "empty region"
 
-        frames_count = self.FRAMES_PER_SEGMENT * (100 / region_percentage)
+        region_size = full_region[1] - full_region[0]
+        frame_size = region_size * (region_percentage / 100)
+        sliding_region_size = region_size - frame_size
+        frames_count = int(self.FRAMES_PER_SEGMENT * (100 / region_percentage))
 
+        capture_windows: List[QWidget] = [self]
         print(self.size())
-        self.grab()
-
-        with open(filename, "w", newline="") as f:
-            pass
+        images = []
+        for i in range(frames_count):
+            frame_center = full_region[0] + (frame_size / 2) + (i / (frames_count - 1) * sliding_region_size)
+            print(i, frame_center, (frame_center - frame_size / 2, frame_center + frame_size / 2))
+            self._plots._on_region_change(None, (frame_center - frame_size / 2, frame_center + frame_size / 2))
+            QtGui.QGuiApplication.processEvents()
+            image = Image.fromqpixmap(self.grab())
+            images.append(image)
 
         if restore_full_region:
-            self._plots._on_region_change(full_region, None)
+            self._plots._on_region_change(None, full_region)
         else:
             self._plots._on_region_change(None, None)
+
+        filename, filter = QFileDialog.getSaveFileName(
+            self, f"Save Animation", default_filename, "Animated GIF (*.gif)"
+        )
+        if not filename:
+            return
+        images[0].save(filename, save_all=True, append_images=images[1:], duration=self.MS_PER_FRAME, loop=0)

--- a/pyqtgraph_scope_plots/animation_plot_table_widget.py
+++ b/pyqtgraph_scope_plots/animation_plot_table_widget.py
@@ -35,6 +35,9 @@ class AnimationPlotsTableWidget(PlotsTableWidget):
 
         frames_count = self.FRAMES_PER_SEGMENT * (100 / region_percentage)
 
+        print(self.size())
+        self.grab()
+
         with open(filename, "w", newline="") as f:
             pass
 

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -16,6 +16,7 @@ import bisect
 import itertools
 import os.path
 import time
+from functools import partial
 from typing import Dict, Tuple, Any, List, Mapping, Optional, Callable, Sequence, cast, Set, Iterable
 
 import numpy as np
@@ -229,7 +230,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget):
         line_width_action.triggered.connect(self._on_line_width_action)
         button_menu.addAction(line_width_action)
         animation_action = QAction("Create Animation", button_menu)
-        animation_action.triggered.connect(self._start_animation_ui_flow)
+        animation_action.triggered.connect(partial(self._start_animation_ui_flow, ""))
         button_menu.addAction(animation_action)
         button_visuals.setMenu(button_menu)
 

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -27,6 +27,7 @@ from PySide6.QtCore import QKeyCombination, QTimer
 from PySide6.QtGui import QAction, QColor, Qt
 from PySide6.QtWidgets import QWidget, QPushButton, QFileDialog, QMenu, QVBoxLayout, QInputDialog, QToolButton
 
+from ..animation_plot_table_widget import AnimationPlotsTableWidget
 from ..multi_plot_widget import MultiPlotWidget
 from ..plots_table_widget import PlotsTableWidget
 from ..search_signals_table import SearchSignalsTable
@@ -37,7 +38,7 @@ from ..transforms_signal_table import TransformsSignalsTable
 from ..util import int_color
 
 
-class CsvLoaderPlotsTableWidget(PlotsTableWidget):
+class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget):
     """Example app-level widget that loads CSV files into the plotter"""
 
     WATCH_INTERVAL_MS = 333  # polls the filesystem metadata for changes this frequently
@@ -227,6 +228,9 @@ class CsvLoaderPlotsTableWidget(PlotsTableWidget):
         line_width_action = QAction("Set Line Width", button_menu)
         line_width_action.triggered.connect(self._on_line_width_action)
         button_menu.addAction(line_width_action)
+        animation_action = QAction("Create Animation", button_menu)
+        animation_action.triggered.connect(self._start_animation_ui_flow)
+        button_menu.addAction(animation_action)
         button_visuals.setMenu(button_menu)
 
         layout = QVBoxLayout()

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -304,7 +304,7 @@ class LinkedMultiPlotWidget(MultiPlotWidget):
             plot_item.sigDragCursorCleared.connect(partial(self._on_drag_cursor_clear, plot_item))
         return plot_item
 
-    def _on_hover_cursor_change(self, sig_plot_item: pg.PlotItem, position: Optional[float]) -> None:
+    def _on_hover_cursor_change(self, sig_plot_item: Optional[pg.PlotItem], position: Optional[float]) -> None:
         for plot_item, _ in self._plot_item_data.items():
             if plot_item is not sig_plot_item and isinstance(plot_item, LiveCursorPlot):
                 with QSignalBlocker(plot_item):
@@ -313,7 +313,7 @@ class LinkedMultiPlotWidget(MultiPlotWidget):
         self._last_hover = position
 
     def _on_region_change(
-        self, sig_plot_item: pg.PlotItem, region: Optional[Union[float, Tuple[float, float]]]
+        self, sig_plot_item: Optional[pg.PlotItem], region: Optional[Union[float, Tuple[float, float]]]
     ) -> None:
         for plot_item, _ in self._plot_item_data.items():
             if plot_item is not sig_plot_item and isinstance(plot_item, RegionPlot):
@@ -322,7 +322,7 @@ class LinkedMultiPlotWidget(MultiPlotWidget):
         self.sigCursorRangeChanged.emit(region)
         self._last_region = region
 
-    def _on_poi_change(self, sig_plot_item: pg.PlotItem, pois: List[float]) -> None:
+    def _on_poi_change(self, sig_plot_item: Optional[pg.PlotItem], pois: List[float]) -> None:
         for plot_item, _ in self._plot_item_data.items():
             if plot_item is not sig_plot_item and isinstance(plot_item, PointsOfInterestPlot):
                 with QSignalBlocker(plot_item):


### PR DESCRIPTION
Add a function to create an animated GIF by scrolling through the selected region (or implicitly, the entire dataset). Probably more useful with the XY plots, and additional windows are composed side-by-side.

Currently, the only user-tunable parameter is the fraction of the region each frame presents. Future work could provide more knobs.