### PR TITLE
Multi-XY plots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 license = "Apache-2.0"
 dependencies = [
-    "PySide6~=6.6",
+    "PySide6~=6.6,!=6.9.1",  # unit tests fail on 6.9.1
     "pyqtgraph~=0.13",
     "pillow>=9.0",
     "pandas~=2.0",

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -386,8 +386,10 @@ class DroppableMultiPlotWidget(MultiPlotWidget):
 
     def _merge_data_into_item(self, source_data_names: List[str], target_plot_index: int, insert: bool = False) -> None:
         """Merges a data (by name) into a target PlotItem, overlaying both on the same plot"""
+        if len(source_data_names) == 0:  # notihng to be done
+            return
+
         created_data_names = []  # list of data names that were successfully created / moved
-        assert len(source_data_names) > 0
         if not insert:  # merge mode
             target_plot_widget = self.widget(target_plot_index)
             if not isinstance(target_plot_widget, pg.PlotWidget):

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -389,7 +389,7 @@ class DroppableMultiPlotWidget(MultiPlotWidget):
             if isinstance(target_plot_item, EnumWaveformPlot):  # can't merge into enum plots
                 return
             for source_data_name in source_data_names:
-                if len(self._plot_item_data[target_plot_item]) > 0:  # check for merge-ability, for empty plots
+                if len(self._plot_item_data[target_plot_item]) > 0:  # check for merge-ability, for nonempty plots
                     if (
                         self._data_items[self._plot_item_data[target_plot_item][0] or ""][1]
                         != self._data_items[source_data_name][1]
@@ -415,8 +415,8 @@ class DroppableMultiPlotWidget(MultiPlotWidget):
                 for source_data_name in source_data_names[1:]:
                     if self._data_items[source_data_names[0]][1] != self._data_items[source_data_name][1]:
                         continue
-                    self._plot_item_data[plot_item].append(source_data_names[0])
-                    created_data_names.append(source_data_names[0])
+                    self._plot_item_data[plot_item].append(source_data_name)
+                    created_data_names.append(source_data_name)
 
             self._update_plots_x_axis()
 

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -359,6 +359,13 @@ class LinkedMultiPlotWidget(MultiPlotWidget):
 
 
 class DragTargetOverlay(QWidget):
+    def __init__(self, parent: QWidget):
+        super().__init__(parent)
+        # these prevent overlay flickering when the overlay intercepts the drag
+        # and cancels the underlying widget's drag
+        self.setAcceptDrops(True)
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
+
     def paintEvent(self, event: QPaintEvent) -> None:
         painter = QPainter()
         painter.begin(self)

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -35,7 +35,7 @@ class PlotsTableWidget(QSplitter):
     class PlotsTableMultiPlots(DroppableMultiPlotWidget, LinkedMultiPlotWidget):
         """MultiPlotWidget used in PlotsTableWidget with required mixins."""
 
-    class PlotsTableSignalsTable(DraggableSignalsTable, XyTable, TransformsSignalsTable, StatsSignalsTable):
+    class PlotsTableSignalsTable(XyTable, DraggableSignalsTable, TransformsSignalsTable, StatsSignalsTable):
         """SignalsTable used in PlotsTableWidget with required mixins."""
 
         def __init__(self, plots: MultiPlotWidget, *args: Any, **kwargs: Any) -> None:

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -40,8 +40,9 @@ class XyPlotWidget(pg.PlotWidget):  # type: ignore[misc]
         self.setAcceptDrops(True)
 
     def add_xy(self, x_name: str, y_name: str) -> None:
-        self._xys.append((x_name, y_name))
-        self._update()
+        if (x_name, y_name) not in self._xys:
+            self._xys.append((x_name, y_name))
+            self._update()
 
     def set_range(self, region: Tuple[float, float]) -> None:
         self._region = region

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -88,7 +88,7 @@ class XyPlotWidget(pg.PlotWidget):  # type: ignore[misc]
             y_color = self._parent._data_items.get(y_name, QColor("white"))
             fade_segments = min(
                 self.FADE_SEGMENTS, xt_hi - xt_lo
-            )  # keep track of the x time indices, offset for y time indices
+            )  # keep track of the x time indices, apply offset for y time indices
             last_segment_end = xt_lo
             for i in range(fade_segments):
                 this_end = int(i / (fade_segments - 1) * (xt_hi - xt_lo)) + xt_lo

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -21,7 +21,7 @@ from PySide6.QtGui import QAction, QColor
 from PySide6.QtWidgets import QMenu, QTableWidgetItem, QMessageBox
 from numpy import typing as npt
 
-from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable
+from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable, DraggableSignalsTable
 from .transforms_signal_table import TransformsSignalsTable
 
 
@@ -89,7 +89,7 @@ class XyPlotWidget(pg.PlotWidget):  # type: ignore[misc]
                 self.addItem(curve)
 
 
-class XyTable(ContextMenuSignalsTable, HasRegionSignalsTable, HasDataSignalsTable):
+class XyTable(DraggableSignalsTable, ContextMenuSignalsTable, HasRegionSignalsTable, HasDataSignalsTable):
     """Mixin into SignalsTable that adds the option to open an XY plot in a separate window."""
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -97,15 +97,6 @@ class XyTable(ContextMenuSignalsTable, HasRegionSignalsTable, HasDataSignalsTabl
         self._xy_action = QAction("Create X-Y Plot", self)
         self._xy_action.triggered.connect(self._on_xy)
         self._xy_plots: List[XyPlotWidget] = []
-
-        self._ordered_selects: List[QTableWidgetItem] = []
-        self.itemSelectionChanged.connect(self._on_select_changed)
-
-    def _on_select_changed(self) -> None:
-        # since selectedItems is not ordered by selection, keep an internal order by tracking changes
-        new_selects = [item for item in self.selectedItems() if item not in self._ordered_selects]
-        self._ordered_selects = [item for item in self._ordered_selects if item in self.selectedItems()]
-        self._ordered_selects.extend(new_selects)
 
     def _populate_context_menu(self, menu: QMenu) -> None:
         super()._populate_context_menu(menu)

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -97,7 +97,7 @@ def test_empty_default_plots(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 def test_plot_merge(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     qtbot.waitUntil(lambda: plot._plots.count() == 3)  # wait for plots to be ready
 
-    plot._plots._merge_data_into_item("0", 1)  # merge
+    plot._plots._merge_data_into_item(["0"], 1)  # merge
     qtbot.waitUntil(lambda: plot._plots.count() == 2)  # wait for widgets to merge
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 2
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(1)).getPlotItem()).listDataItems()) == 1
@@ -106,7 +106,7 @@ def test_plot_merge(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     assert plot._table.item(1, plot._table.COL_NAME).text() == "1"
     assert plot._table.item(2, plot._table.COL_NAME).text() == "2"
 
-    plot._plots._merge_data_into_item("0", 1)  # move
+    plot._plots._merge_data_into_item(["0"], 1)  # move
     qtbot.waitUntil(lambda: plot._plots.count() == 2)
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 1
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(1)).getPlotItem()).listDataItems()) == 2
@@ -115,7 +115,7 @@ def test_plot_merge(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     assert plot._table.item(1, plot._table.COL_NAME).text() == "1"
     assert plot._table.item(2, plot._table.COL_NAME).text() == "2"
 
-    plot._plots._merge_data_into_item("1", 1)  # merge all
+    plot._plots._merge_data_into_item(["1"], 1)  # merge all
     qtbot.waitUntil(lambda: plot._plots.count() == 1)
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 3
     assert plot._table.rowCount() == 3  # signals table should not change
@@ -123,14 +123,14 @@ def test_plot_merge(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     assert plot._table.item(1, plot._table.COL_NAME).text() == "1"
     assert plot._table.item(2, plot._table.COL_NAME).text() == "2"
 
-    plot._plots._merge_data_into_item("2", 0, insert=True)  # insert at top
+    plot._plots._merge_data_into_item(["2"], 0, insert=True)  # insert at top
     qtbot.waitUntil(lambda: plot._plots.count() == 2)  # new plot created
     assert plot._table.rowCount() == 3  # signals table should not change
     assert plot._table.item(0, plot._table.COL_NAME).text() == "0"
     assert plot._table.item(1, plot._table.COL_NAME).text() == "1"
     assert plot._table.item(2, plot._table.COL_NAME).text() == "2"
 
-    plot._plots._merge_data_into_item("0", 2, insert=True)  # insert at bottom
+    plot._plots._merge_data_into_item(["0"], 2, insert=True)  # insert at bottom
     qtbot.waitUntil(lambda: plot._plots.count() == 3)
 
 
@@ -147,10 +147,10 @@ def test_invalid_plot_merge(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
     qtbot.waitUntil(lambda: plot._plots.count() == 5)  # wait for plots to be ready
 
-    plot._plots._merge_data_into_item("3", 0)  # invalid merge, different types
-    plot._plots._merge_data_into_item("0", 3)  # invalid merge, different types
-    plot._plots._merge_data_into_item("3", 4)  # can't merge enums
-    plot._plots._merge_data_into_item("4", 3)  # can't merge enums
+    plot._plots._merge_data_into_item(["3"], 0)  # invalid merge, different types
+    plot._plots._merge_data_into_item(["0"], 3)  # invalid merge, different types
+    plot._plots._merge_data_into_item(["3"], 4)  # can't merge enums
+    plot._plots._merge_data_into_item(["4"], 3)  # can't merge enums
 
     assert plot._plots.count() == 5  # check nothing changes
 
@@ -159,7 +159,7 @@ def test_plot_remove(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     plot._plots.remove_plot_items(["1"])
     qtbot.waitUntil(lambda: plot._plots.count() == 2)  # plot removed
 
-    plot._plots._merge_data_into_item("2", 0)  # merge all into top
+    plot._plots._merge_data_into_item(["2"], 0)  # merge all into top
     qtbot.waitUntil(lambda: plot._plots.count() == 1)
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 2
 

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -134,6 +134,28 @@ def test_plot_merge(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     qtbot.waitUntil(lambda: plot._plots.count() == 3)
 
 
+def test_plot_merge_multi(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    qtbot.waitUntil(lambda: plot._plots.count() == 3)  # wait for plots to be ready
+
+    plot._plots._merge_data_into_item(["0", "1"], 0)  # merge into self, including self
+    qtbot.waitUntil(lambda: plot._plots.count() == 2)  # wait for widgets to merge
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 2
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(1)).getPlotItem()).listDataItems()) == 1
+
+    plot._plots._merge_data_into_item(["0", "1"], 1)  # merge into other, not including self
+    qtbot.waitUntil(lambda: plot._plots.count() == 1)  # wait for widgets to merge
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 3
+
+    plot._plots._merge_data_into_item(["1", "2"], 2, insert=True)  # insert at bottom
+    qtbot.waitUntil(lambda: plot._plots.count() == 2)
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 1
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(1)).getPlotItem()).listDataItems()) == 2
+
+    plot._plots._merge_data_into_item(["0", "1", "2"], 2, insert=True)  # insert all
+    qtbot.waitUntil(lambda: plot._plots.count() == 1)
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 3
+
+
 def test_invalid_plot_merge(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     plot._set_data_items(
         [
@@ -193,7 +215,7 @@ def test_no_excessive_plots(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     qtbot.waitUntil(lambda: plot._plots.count() == 1)  # should just create an empty plot
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 0
 
-    plot._plots._merge_data_into_item("A", 0)  # check that stuff can be dragged into the default empty plot
+    plot._plots._merge_data_into_item(["A"], 0)  # check that stuff can be dragged into the default empty plot
     qtbot.waitUntil(lambda: plot._plots.count() == 1)
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 1
 

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -12,24 +12,65 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import pytest
+from PySide6.QtGui import QColor
 from pytestqt.qtbot import QtBot
 
 from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
-from .test_base_plot import plot
+from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
+
+
+@pytest.fixture()
+def plot(qtbot: QtBot) -> PlotsTableWidget:
+    """Creates a signals plot with multiple data items"""
+    plot = PlotsTableWidget()
+    plot._set_data_items(
+        [
+            ("0", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
+            ("1", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
+            ("2", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
+        ]
+    )
+    plot._set_data(
+        {
+            "0": ([0, 1, 2], [0, 1, 2]),
+            "1": ([0, 1, 2], [2, 1, 0]),
+            "2": ([1, 2, 3], [0, 1, 2]),  # offset in time but evenly spaced
+            "X": ([0, 1, 4], [0, 1, 2]),  # not evenly spaced
+        }
+    )
+    qtbot.addWidget(plot)
+    plot.show()
+    qtbot.waitExposed(plot)
+    return plot
 
 
 def test_xy_create(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     # test that xy creation doesn't error out and follows the user order
-    # use items 1 and 2 since they share the same indices
-    plot._table.item(2, 0).setSelected(True)
     plot._table.item(1, 0).setSelected(True)
+    plot._table.item(0, 0).setSelected(True)
     xy_plot = plot._table._on_xy()
     assert xy_plot is not None
-    assert xy_plot._xys == [("2", "1")]
+    assert xy_plot._xys == [("1", "0")]
 
     plot._table.clearSelection()
+    plot._table.item(0, 0).setSelected(True)
     plot._table.item(1, 0).setSelected(True)
+    xy_plot = plot._table._on_xy()
+    assert xy_plot is not None
+    assert xy_plot._xys == [("0", "1")]
+
+    qtbot.wait(10)  # wait for rendering to happen
+
+
+def test_xy_offset(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    plot._table.item(0, 0).setSelected(True)
     plot._table.item(2, 0).setSelected(True)
     xy_plot = plot._table._on_xy()
     assert xy_plot is not None
-    assert xy_plot._xys == [("1", "2")]
+    assert xy_plot._xys == [("0", "2")]
+
+    xy_plot.add_xy("2", "0")
+    assert xy_plot._xys == [("0", "2"), ("2", "0")]
+
+    qtbot.wait(10)  # wait for rendering to happen


### PR DESCRIPTION
Add support for multiple overlaid X-Y plots, by drag-and-drop. Improves robustness of X-Y plots to non-identical indices and truncates the X and Y series as needed (but not supporting point misalignment).

Also adds support for dragging-and-dropping multiple data items onto the timeseries plot.

Infrastructure: moves selection order tracking to DraggableSignalsTable, where the drag presents selected data items in selection order