### PR TITLE
Save / load config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,18 @@ dev = [
 profile = "black"
 
 [tool.mypy]
+plugins = [
+    "pydantic.mypy"
+]
 python_version = "3.8"
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true
 strict = true
-plugins = "pydantic.mypy"
+
+[[tool.mypy.overrides]]
+module = ["pydantic.*"]
+follow_imports = "silent"
 
 [[tool.mypy.overrides]]
 module = ["pyqtgraph.*", "simpleeval.*", "pytestqt.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,10 +66,6 @@ disallow_untyped_defs = true
 strict = true
 
 [[tool.mypy.overrides]]
-module = ["pydantic.*"]
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = ["pyqtgraph.*", "simpleeval.*", "pytestqt.*"]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ strict = true
 
 [[tool.mypy.overrides]]
 module = ["pydantic.*"]
-follow_imports = "silent"
+ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = ["pyqtgraph.*", "simpleeval.*", "pytestqt.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     "pillow>=9.0",
     "pandas~=2.0",
     "numpy>=1.19",
-    "simpleeval==1.0.3",
+    "pydantic>=2.0",
+    "simpleeval>=1.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "black~=23.3",
     "isort~=5.9.2",
     "flake8~=3.9.2",
+    "types-PyYAML",
     "pytest~=6.2.4",
     "pytest-qt~=4.4",
     "pytest-cov~=6.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "numpy>=1.19",
     "pydantic>=2.0",
     "simpleeval>=1.0",
+    "PyYAML>=6.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ profile = "black"
 plugins = [
     "pydantic.mypy"
 ]
-python_version = "3.8"
+python_version = "3.9"  # pydantic uses 3.9 syntax internally
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true
 strict = true
+plugins = "pydantic.mypy"
 
 [[tool.mypy.overrides]]
 module = ["pyqtgraph.*", "simpleeval.*", "pytestqt.*"]

--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -35,3 +35,5 @@ from .search_signals_table import SearchSignalsTable
 from .xy_plot_table import XyTable
 
 from .time_axis import TimeAxisItem
+
+from .save_restore_model import HasSaveRestoreModel, DataTopModel, BaseTopModel

--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -36,4 +36,4 @@ from .xy_plot_table import XyTable
 
 from .time_axis import TimeAxisItem
 
-from .save_restore_model import HasSaveRestoreModel, DataTopModel, BaseTopModel
+from .save_restore_model import HasSaveLoadConfig, DataTopModel, BaseTopModel

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -130,7 +130,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
     def _get_model_bases(cls) -> Tuple[List[ModelMetaclass], List[ModelMetaclass]]:
         data_bases, misc_bases = super()._get_model_bases()
         plots_data_bases, plots_misc_bases = cls.Plots._get_model_bases()
-        table_data_bases, table_misc_bases = cls.Plots._get_model_bases()
+        table_data_bases, table_misc_bases = cls.CsvSignalsTable._get_model_bases()
         return table_data_bases + plots_data_bases + data_bases, table_misc_bases + plots_misc_bases + misc_bases
 
     def _write_model(self, model: BaseTopModel) -> None:
@@ -396,7 +396,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         if not filename:  # nothing selected, user canceled
             return
         with open(filename, "w") as f:
-            f.write(yaml.dump(self._dump_model(self._table._data_items.keys()).model_dump()))
+            f.write(yaml.dump(self._dump_model(self._table._data_items.keys()).model_dump(), sort_keys=False))
 
     def _on_load_config(self) -> None:
         filename, _ = QFileDialog.getOpenFileName(None, "Load config", filter="YAML files (*.yml)")

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -255,6 +255,9 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         save_state_action = QAction("Save State", button_menu)
         save_state_action.triggered.connect(self._on_save_state)
         button_menu.addAction(save_state_action)
+        load_state_action = QAction("Load State", button_menu)
+        load_state_action.triggered.connect(self._on_load_state)
+        button_menu.addAction(load_state_action)
 
         layout = QVBoxLayout()
         layout.addWidget(button_load)
@@ -384,3 +387,12 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         model_str = yaml.dump(model.model_dump())
         with open(filename, "w") as f:
             f.write(model_str)
+
+    def _on_load_state(self):
+        filename, _ = QFileDialog.getOpenFileName(None, "Load state", filter="YAML files (*.yml)")
+        if not filename:  # nothing selected, user canceled
+            return
+        with open(filename, "r") as f:
+            model = self._create_skeleton_model_type()(**yaml.safe_load(f))
+
+        self._restore_model(model)

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -134,10 +134,10 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         data_bases, misc_bases = self._table._get_model_bases(data_bases, misc_bases)
         return data_bases, misc_bases
 
-    def _save_model(self, model: BaseTopModel) -> None:
-        super()._save_model(model)
-        self._plots._save_model(model)
-        self._table._save_model(model)
+    def _write_model(self, model: BaseTopModel) -> None:
+        super()._write_model(model)
+        self._plots._write_model(model)
+        self._table._write_model(model)
 
     def _restore_model(self, model: BaseTopModel) -> None:
         super()._restore_model(model)
@@ -396,11 +396,8 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         filename, _ = QFileDialog.getSaveFileName(None, "Save state", filter="YAML files (*.yml)")
         if not filename:  # nothing selected, user canceled
             return
-        model = self._create_skeleton_model(self._table._data_items.keys())
-        self._save_model(model)
-        model_str = yaml.dump(model.model_dump())
         with open(filename, "w") as f:
-            f.write(model_str)
+            f.write(yaml.dump(self._dump_model(self._table._data_items.keys()).model_dump()))
 
     def _on_load_state(self) -> None:
         filename, _ = QFileDialog.getOpenFileName(None, "Load state", filter="YAML files (*.yml)")

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -378,7 +378,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
 
         return self
 
-    def _on_save_state(self):
+    def _on_save_state(self) -> None:
         filename, _ = QFileDialog.getSaveFileName(None, "Save state", filter="YAML files (*.yml)")
         if not filename:  # nothing selected, user canceled
             return
@@ -388,11 +388,12 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         with open(filename, "w") as f:
             f.write(model_str)
 
-    def _on_load_state(self):
+    def _on_load_state(self) -> None:
         filename, _ = QFileDialog.getOpenFileName(None, "Load state", filter="YAML files (*.yml)")
         if not filename:  # nothing selected, user canceled
             return
         with open(filename, "r") as f:
-            model = self._create_skeleton_model_type()(**yaml.safe_load(f))
+            _, top_model_cls = self._create_skeleton_model_type()
+            model = top_model_cls(**yaml.safe_load(f))
 
         self._restore_model(model)

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -46,7 +46,7 @@ class TupleSafeLoader(yaml.SafeLoader):
     pass
 
 
-def construct_python_tuple(loader, node):
+def construct_python_tuple(loader: TupleSafeLoader, node: Any) -> Tuple[Any, ...]:
     return tuple(loader.construct_sequence(node))
 
 

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -42,6 +42,17 @@ from ..transforms_signal_table import TransformsSignalsTable
 from ..util import int_color
 
 
+class TupleSafeLoader(yaml.SafeLoader):
+    pass
+
+
+def construct_python_tuple(loader, node):
+    return tuple(loader.construct_sequence(node))
+
+
+TupleSafeLoader.add_constructor("tag:yaml.org,2002:python/tuple", construct_python_tuple)
+
+
 class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, HasSaveRestoreModel):
     """Example app-level widget that loads CSV files into the plotter"""
 
@@ -394,6 +405,6 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
             return
         with open(filename, "r") as f:
             _, top_model_cls = self._create_skeleton_model_type()
-            model = top_model_cls(**yaml.safe_load(f))
+            model = top_model_cls(**yaml.load(f, Loader=TupleSafeLoader))
 
         self._restore_model(model)

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -131,15 +131,18 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
     ) -> Tuple[List[ModelMetaclass], List[ModelMetaclass]]:
         data_bases, misc_bases = super()._get_model_bases(data_bases, misc_bases)
         data_bases, misc_bases = self._plots._get_model_bases(data_bases, misc_bases)
+        data_bases, misc_bases = self._table._get_model_bases(data_bases, misc_bases)
         return data_bases, misc_bases
 
     def _save_model(self, model: BaseTopModel) -> None:
         super()._save_model(model)
         self._plots._save_model(model)
+        self._table._save_model(model)
 
     def _restore_model(self, model: BaseTopModel) -> None:
         super()._restore_model(model)
         self._plots._restore_model(model)
+        self._table._restore_model(model)
 
     def _transform_data(
         self,

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -22,7 +22,6 @@ import pyqtgraph as pg
 from PySide6.QtCore import QSignalBlocker, QPoint, QSize, Signal
 from PySide6.QtGui import QColor, Qt, QDropEvent, QDragLeaveEvent, QPainter, QBrush, QDragMoveEvent, QPaintEvent
 from PySide6.QtWidgets import QWidget, QSplitter
-from pydantic._internal._model_construction import ModelMetaclass
 
 from .enum_waveform_plotitem import EnumWaveformPlot
 from .interactivity_mixins import PointsOfInterestPlot, RegionPlot, LiveCursorPlot, DraggableCursorPlot

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -22,7 +22,6 @@ import pyqtgraph as pg
 from PySide6.QtCore import QSignalBlocker, QPoint, QSize, Signal
 from PySide6.QtGui import QColor, Qt, QDropEvent, QDragLeaveEvent, QPainter, QBrush, QDragMoveEvent, QPaintEvent
 from PySide6.QtWidgets import QWidget, QSplitter
-from pydantic import BaseModel
 from pydantic._internal._model_construction import ModelMetaclass
 
 from .enum_waveform_plotitem import EnumWaveformPlot

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -45,7 +45,7 @@ class EnumWaveformInteractivePlot(
     POI_ANCHOR = (0, 0.5)
 
 
-class MultiPlotStateModel(BaseModel):
+class MultiPlotStateModel(BaseTopModel):
     widget_data_items: List[List[str]] = []  # window index -> list of data items
 
 
@@ -330,7 +330,7 @@ class MultiPlotWidget(HasSaveRestoreModel, QSplitter):
                 plot_item.enableAutoRange(axis="y", enable=enable)
 
 
-class LinkedMultiPlotStateModel(BaseModel):
+class LinkedMultiPlotStateModel(BaseTopModel):
     region: Optional[Union[float, Tuple[float, float]]] = None
     pois: List[float] = []
 

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -111,7 +111,28 @@ class MultiPlotWidget(HasSaveRestoreModel, QSplitter):
 
     def _restore_model(self, model: BaseTopModel) -> None:
         super()._restore_model(model)
-        raise NotImplementedError
+
+        # remove all existing plots
+        self._plot_item_data = {}
+        self._clean_plot_widgets()
+
+        # create plots from model
+        assert isinstance(model, MultiPlotStateModel)
+        for widget_data_items in model.widget_data_items:
+            if len(widget_data_items) <= 0:  # skip empty plots
+                continue
+            color, plot_type = self._data_items.get(widget_data_items[0], (None, None))
+            if plot_type is None:
+                continue
+            add_plot_item = self._init_plot_item(self._create_plot_item(plot_type))
+            plot_widget = pg.PlotWidget(plotItem=add_plot_item)
+            self.addWidget(plot_widget)
+            self._plot_item_data[add_plot_item] = widget_data_items
+
+        self._check_create_default_plot()
+        self._update_plots_x_axis()
+        self._update_data_name_to_plot_item()
+        self._update_plots()  # TODO can be removed and dedup'd
 
     def render_value(self, data_name: str, value: float) -> str:
         """Float-to-string conversion for a value. Optionally override this to provide smarter precision."""

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -97,8 +97,8 @@ class MultiPlotWidget(HasSaveRestoreModel, QSplitter):
         data_bases, misc_bases = super()._get_model_bases(data_bases, misc_bases)
         return data_bases, [MultiPlotStateModel] + misc_bases
 
-    def _save_model(self, model: BaseTopModel) -> None:
-        super()._save_model(model)
+    def _write_model(self, model: BaseTopModel) -> None:
+        super()._write_model(model)
         assert isinstance(model, MultiPlotStateModel)
         model.widget_data_items = []
         for i in range(self.count()):
@@ -351,8 +351,8 @@ class LinkedMultiPlotWidget(MultiPlotWidget, HasSaveRestoreModel):
         data_bases, misc_bases = super()._get_model_bases(data_bases, misc_bases)
         return data_bases, [LinkedMultiPlotStateModel] + misc_bases
 
-    def _save_model(self, model: BaseTopModel) -> None:
-        super()._save_model(model)
+    def _write_model(self, model: BaseTopModel) -> None:
+        super()._write_model(model)
         assert isinstance(model, LinkedMultiPlotStateModel)
         model.region = self._last_region
         model.pois = self._last_pois

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -72,8 +72,10 @@ class HasSaveRestoreModel:
         It is guaranteed that by the time the subclasses of this have the load called, the data_items
         are correctly populated (responsibility of the top-level load). HOWEVER, some data_items
         restores may fail, so this should check for the existence of each data_item.
+        data values will not be valid.
 
-        TODO: definition for delayed single bulk update
+        data values will be set after all mixins have completed restore.
+        This function does not need to duplicate any work that would otherwise be done on a data value set.
 
         IMPLEMENT ME."""
         pass

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -65,7 +65,13 @@ class HasSaveRestoreModel:
         top_model = top_model_cls(data={data_name: data_model_cls() for data_name in data_names})
         return top_model
 
-    def _save_model(self, model: BaseTopModel) -> None:
+    def _dump_model(self, data_names: Iterable[str]) -> BaseTopModel:
+        """For top-level self, generate the save state model. Convenience wrapper around model creation and writing."""
+        model = self._create_skeleton_model(data_names)
+        self._write_model(model)
+        return model
+
+    def _write_model(self, model: BaseTopModel) -> None:
         """Saves the data into the top-level model. model.data is pre-populated with models for every data item.
         Mutates the model in-place.
 

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -47,7 +47,7 @@ class HasSaveLoadConfig:
 
     @classmethod
     def _get_model_bases(cls) -> Tuple[List[ModelMetaclass], List[ModelMetaclass]]:
-        """Returns the (data bases, misc bases) of this. Typically implemented as a concat of the incoming types.
+        """Returns the (data bases, misc bases) of this class.
         Inspects each subclasses' TOP_MODEL_BASES and DATA_MODEL_BASES, so no implementation is required
         if all the HasSaveLoadConfig are mixins into the top-level class.
 

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -50,7 +50,8 @@ class HasSaveRestoreModel:
         return data_bases, misc_bases
 
     def _create_skeleton_model(self, data_names: Iterable[str]) -> BaseTopModel:
-        """Returns an empty model of the correct type that can be passed into _save_model."""
+        """Returns an empty model of the correct type (containing all _get_model_bases)
+        that can be passed into _save_model."""
         data_bases, model_bases = self._get_model_bases([DataTopModel], [BaseTopModel])
         data_model_cls = pydantic.create_model("DataModel", __base__=tuple(data_bases))
         top_model_cls = pydantic.create_model(

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -50,15 +50,18 @@ class HasSaveRestoreModel:
         IMPLEMENT ME."""
         return data_bases, misc_bases
 
+    def _create_skeleton_model_type(self) -> Type[BaseTopModel]:
+        data_bases, model_bases = self._get_model_bases([DataTopModel], [BaseTopModel])
+        data_model_cls = pydantic.create_model("DataModel", __base__=tuple(data_bases))  # type: ignore
+        return pydantic.create_model(
+            "TopModel", __base__=tuple(model_bases), data=(Dict[str, data_model_cls], ...)  # type: ignore
+        )
+
     def _create_skeleton_model(self, data_names: Iterable[str]) -> BaseTopModel:
         """Returns an empty model of the correct type (containing all _get_model_bases)
         that can be passed into _save_model."""
-        data_bases, model_bases = self._get_model_bases([DataTopModel], [BaseTopModel])
         data_model_cls = pydantic.create_model("DataModel", __base__=tuple(data_bases))  # type: ignore
-        top_model_cls = pydantic.create_model(
-            "TopModel", __base__=tuple(model_bases), data=(Dict[str, data_model_cls], ...)  # type: ignore
-        )
-        top_model = top_model_cls(data={data_name: data_model_cls() for data_name in data_names})
+        top_model = self._create_skeleton_model_type()(data={data_name: data_model_cls() for data_name in data_names})
         return top_model  # type: ignore
 
     def _save_model(self, model: BaseTopModel) -> None:

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -70,7 +70,9 @@ class HasSaveRestoreModel:
         """Restores data from the top-level model.
 
         It is guaranteed that by the time the subclasses of this have the load called, the data_items
-        are correctly populated (responsibility of the top-level load).
+        are correctly populated (responsibility of the top-level load). HOWEVER, some data_items
+        restores may fail, so this should check for the existence of each data_item.
+
         TODO: definition for delayed single bulk update
 
         IMPLEMENT ME."""

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -16,6 +16,7 @@ from typing import List, Type, Tuple, Dict, Iterable
 
 import pydantic
 from pydantic import BaseModel
+from pydantic._internal._model_construction import ModelMetaclass
 
 
 class DataTopModel(BaseModel):
@@ -42,8 +43,8 @@ class HasSaveRestoreModel:
     """
 
     def _get_model_bases(
-        self, data_bases: List[Type[BaseModel]], misc_bases: List[Type[BaseModel]]
-    ) -> Tuple[List[Type[BaseModel]], List[Type[BaseModel]]]:
+        self, data_bases: List[ModelMetaclass], misc_bases: List[ModelMetaclass]
+    ) -> Tuple[List[ModelMetaclass], List[ModelMetaclass]]:
         """Returns the (data bases, misc bases) of this. Typically implemented as a concat of the incoming types.
 
         IMPLEMENT ME."""
@@ -53,12 +54,12 @@ class HasSaveRestoreModel:
         """Returns an empty model of the correct type (containing all _get_model_bases)
         that can be passed into _save_model."""
         data_bases, model_bases = self._get_model_bases([DataTopModel], [BaseTopModel])
-        data_model_cls = pydantic.create_model("DataModel", __base__=tuple(data_bases))
+        data_model_cls = pydantic.create_model("DataModel", __base__=tuple(data_bases))  # type: ignore
         top_model_cls = pydantic.create_model(
-            "TopModel", __base__=tuple(model_bases), data=(Dict[str, data_model_cls], ...)
+            "TopModel", __base__=tuple(model_bases), data=(Dict[str, data_model_cls], ...)  # type: ignore
         )
-        top_model = top_model_cls(data={data_name: data_model_cls() for data_name in data_names})  # type: BaseTopModel
-        return top_model
+        top_model = top_model_cls(data={data_name: data_model_cls() for data_name in data_names})
+        return top_model  # type: ignore
 
     def _save_model(self, model: BaseTopModel) -> None:
         """Saves the data into the top-level model. model.data is pre-populated with models for every data item.

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from typing import List, Type, Tuple
+
+from pydantic import BaseModel
+
+
+class BaseTopModel(BaseModel):
+    pass
+
+
+class HasSaveRestoreModel:
+    """Mixin class to table and multiplotwidget that defines functionality
+    to save the GUI state to a Pydantic model and by extension JSON.
+
+    The model is broken down into two sections: data (keyed by data name, sorted by data order,
+    contains per-data items like timeshift and transforms), and misc (which contains everything else,
+    typically UI state like regions and X-Y plot configurations).
+
+    Each subclass of this (typically a mixin into table or multiplotwidget) defines BaseModel
+    mixins into both data and misc, a save function for model (including the data), and
+    a load function for model (including the data).
+    """
+
+    def _get_model_bases(
+        self, data_bases: List[Type[BaseModel]], misc_bases: List[Type[BaseModel]]
+    ) -> Tuple[List[Type[BaseModel]], List[Type[BaseModel]]]:
+        """Returns the (data bases, misc bases) of this. Typically implemented as a concat of the incoming types.
+
+        IMPLEMENT ME."""
+        return data_bases, misc_bases
+
+    def _save_model(self, model: BaseTopModel) -> None:
+        """Saves the data into the top-level model. Mutates the model in-place.
+
+        IMPLEMENT ME."""
+        pass
+
+    def _restore_model(self, model: BaseTopModel) -> None:
+        """Restores data from the top-level model.
+
+        It is guaranteed that by the time the subclasses of this have the load called, the data_items
+        are correctly populated (responsibility of the top-level load).
+        TODO: definition for delayed single bulk update
+
+        IMPLEMENT ME."""
+        pass

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -373,6 +373,7 @@ class ColorPickerSignalsTable(ContextMenuSignalsTable, HasSaveRestoreModel):
 
     def _restore_model(self, model: BaseTopModel) -> None:
         super()._restore_model(model)
+        assert isinstance(data_model, ColorPickerDataStateModel)
         data_name_colors = [
             (data_name, QColor(data_model.color[0], data_model.color[1], data_model.color[2]))
             for data_name, data_model in model.data.items()

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -362,8 +362,8 @@ class ColorPickerSignalsTable(ContextMenuSignalsTable, HasSaveRestoreModel):
         data_bases, misc_bases = super()._get_model_bases(data_bases, misc_bases)
         return [ColorPickerDataStateModel] + data_bases, misc_bases
 
-    def _save_model(self, model: BaseTopModel) -> None:
-        super()._save_model(model)
+    def _write_model(self, model: BaseTopModel) -> None:
+        super()._write_model(model)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, ColorPickerDataStateModel)
             color = self._colors.get(data_name, None)

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -373,12 +373,12 @@ class ColorPickerSignalsTable(ContextMenuSignalsTable, HasSaveRestoreModel):
 
     def _restore_model(self, model: BaseTopModel) -> None:
         super()._restore_model(model)
-        assert isinstance(model, ColorPickerDataStateModel)
-        data_name_colors = [
-            (data_name, QColor(data_model.color[0], data_model.color[1], data_model.color[2]))
-            for data_name, data_model in model.data.items()
-            if data_model.color is not None
-        ]
+        data_name_colors = []
+        for data_name, data_model in model.data.items():
+            assert isinstance(data_model, ColorPickerDataStateModel)
+            if data_model.color is None:
+                continue
+            data_name_colors.append((data_name, QColor(data_model.color[0], data_model.color[1], data_model.color[2])))
         self.sigColorChanged.emit(data_name_colors)
 
     def _populate_context_menu(self, menu: QMenu) -> None:

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -23,10 +23,9 @@ import numpy.typing as npt
 from PySide6.QtCore import QMimeData, QPoint, Signal, QObject, QThread
 from PySide6.QtGui import QColor, Qt, QAction, QDrag, QPixmap, QMouseEvent
 from PySide6.QtWidgets import QTableWidgetItem, QTableWidget, QHeaderView, QMenu, QLabel, QColorDialog
-from pydantic._internal._model_construction import ModelMetaclass
 
-from .save_restore_model import HasSaveLoadConfig, DataTopModel, BaseTopModel
 from .cache_dict import IdentityCacheDict
+from .save_restore_model import HasSaveLoadConfig, DataTopModel, BaseTopModel
 from .util import not_none
 
 
@@ -363,18 +362,18 @@ class ColorPickerSignalsTable(ContextMenuSignalsTable, HasSaveLoadConfig):
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, ColorPickerDataStateModel)
             color = self._colors.get(data_name, None)
-            if color is None:
-                continue
-            data_model.color = (color.red(), color.green(), color.blue())
+            if color is not None:
+                data_model.color = (color.red(), color.green(), color.blue())
 
     def _load_model(self, model: BaseTopModel) -> None:
         super()._load_model(model)
         data_name_colors = []
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, ColorPickerDataStateModel)
-            if data_model.color is None:
-                continue
-            data_name_colors.append((data_name, QColor(data_model.color[0], data_model.color[1], data_model.color[2])))
+            if data_model.color is not None:
+                data_name_colors.append(
+                    (data_name, QColor(data_model.color[0], data_model.color[1], data_model.color[2]))
+                )
         self.sigColorChanged.emit(data_name_colors)
 
     def _populate_context_menu(self, menu: QMenu) -> None:

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -373,7 +373,7 @@ class ColorPickerSignalsTable(ContextMenuSignalsTable, HasSaveRestoreModel):
 
     def _restore_model(self, model: BaseTopModel) -> None:
         super()._restore_model(model)
-        assert isinstance(data_model, ColorPickerDataStateModel)
+        assert isinstance(model, ColorPickerDataStateModel)
         data_name_colors = [
             (data_name, QColor(data_model.color[0], data_model.color[1], data_model.color[2]))
             for data_name, data_model in model.data.items()

--- a/pyqtgraph_scope_plots/timeshift_signals_table.py
+++ b/pyqtgraph_scope_plots/timeshift_signals_table.py
@@ -104,7 +104,11 @@ class TimeshiftSignalsTable(ContextMenuSignalsTable, HasSaveLoadConfig):
         index_by_data_name = {data_name: i for i, data_name in enumerate(self._data_items.keys())}
         for data_name in data_names:
             self._timeshifts[data_name] = timeshift
-            not_none(self.item(index_by_data_name[data_name], self.COL_TIMESHIFT)).setText(str(timeshift))
+            if timeshift == 0:
+                timeshift_str = ""
+            else:
+                timeshift_str = str(timeshift)
+            not_none(self.item(index_by_data_name[data_name], self.COL_TIMESHIFT)).setText(timeshift_str)
         self.sigTimeshiftChanged.emit(data_names)
 
     def apply_timeshifts(

--- a/pyqtgraph_scope_plots/timeshift_signals_table.py
+++ b/pyqtgraph_scope_plots/timeshift_signals_table.py
@@ -53,9 +53,8 @@ class TimeshiftSignalsTable(ContextMenuSignalsTable, HasSaveLoadConfig):
         super()._write_model(model)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, TimeshiftDataStateModel)
-            timeshift = self._timeshifts.get(data_name, None)
-            if timeshift is not None:
-                data_model.timeshift = timeshift
+            timeshift = self._timeshifts.get(data_name, 0)
+            data_model.timeshift = timeshift
 
     def _load_model(self, model: BaseTopModel) -> None:
         super()._load_model(model)

--- a/pyqtgraph_scope_plots/timeshift_signals_table.py
+++ b/pyqtgraph_scope_plots/timeshift_signals_table.py
@@ -75,7 +75,7 @@ class TimeshiftSignalsTable(ContextMenuSignalsTable, HasSaveLoadConfig):
         super().set_data_items(new_data_items)
         for row, (name, color) in enumerate(self._data_items.items()):
             timeshift = self._timeshifts.get(name)
-            if timeshift is not None:
+            if timeshift is not None and timeshift != 0:
                 not_none(self.item(row, self.COL_TIMESHIFT)).setText(str(timeshift))
             else:
                 not_none(self.item(row, self.COL_TIMESHIFT)).setText("")

--- a/pyqtgraph_scope_plots/transforms_signal_table.py
+++ b/pyqtgraph_scope_plots/transforms_signal_table.py
@@ -93,9 +93,8 @@ class TransformsSignalsTable(ContextMenuSignalsTable, HasSaveLoadConfig):
         super()._write_model(model)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, TransformsDataStateModel)
-            transform, _ = self._transforms.get(data_name, (None, None))
-            if transform is not None:
-                data_model.transform = transform
+            transform, _ = self._transforms.get(data_name, ("", None))
+            data_model.transform = transform
 
     def _load_model(self, model: BaseTopModel) -> None:
         super()._load_model(model)

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -22,6 +22,7 @@ from PySide6.QtGui import QAction, QColor, QDragMoveEvent, QDragLeaveEvent, QDro
 from PySide6.QtWidgets import QMenu, QMessageBox
 from numpy import typing as npt
 
+from .save_restore_model import HasSaveLoadConfig, BaseTopModel
 from .multi_plot_widget import DragTargetOverlay
 from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable, DraggableSignalsTable
 from .transforms_signal_table import TransformsSignalsTable
@@ -144,14 +145,43 @@ class XyPlotWidget(pg.PlotWidget):  # type: ignore[misc]
         event.accept()
 
 
-class XyTable(DraggableSignalsTable, ContextMenuSignalsTable, HasRegionSignalsTable, HasDataSignalsTable):
+class XyTableStateModel(BaseTopModel):
+    xy_data_items: List[List[Tuple[str, str]]] = []  # window index -> list of (x, y) data items
+
+
+class XyTable(
+    DraggableSignalsTable, ContextMenuSignalsTable, HasRegionSignalsTable, HasDataSignalsTable, HasSaveLoadConfig
+):
     """Mixin into SignalsTable that adds the option to open an XY plot in a separate window."""
+
+    TOP_MODEL_BASES = [XyTableStateModel]
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self._xy_action = QAction("Create X-Y Plot", self)
-        self._xy_action.triggered.connect(self._on_xy)
+        self._xy_action.triggered.connect(self._on_create_xy)
         self._xy_plots: List[XyPlotWidget] = []
+
+    def _write_model(self, model: BaseTopModel) -> None:
+        super()._write_model(model)
+        assert isinstance(model, XyTableStateModel)
+        model.xy_data_items = []
+        for xy_plot in self._xy_plots:
+            model.xy_data_items.append(xy_plot._xys)
+
+    def _load_model(self, model: BaseTopModel) -> None:
+        super()._load_model(model)
+
+        # remove all existing plots
+        for xy_plot in self._xy_plots:
+            xy_plot.close()
+
+        # create plots from model
+        assert isinstance(model, XyTableStateModel)
+        for xy_data_items in model.xy_data_items:
+            xy_plot = self.create_xy()
+            for xy_data_item in xy_data_items:
+                xy_plot.add_xy(*xy_data_item)
 
     def _populate_context_menu(self, menu: QMenu) -> None:
         super()._populate_context_menu(menu)
@@ -172,7 +202,7 @@ class XyTable(DraggableSignalsTable, ContextMenuSignalsTable, HasRegionSignalsTa
         for xy_plot in self._xy_plots:
             xy_plot.set_range(self._range)
 
-    def _on_xy(self) -> Optional[XyPlotWidget]:
+    def _on_create_xy(self) -> Optional[XyPlotWidget]:
         """Creates an XY plot with the selected signal(s) and returns the new plot."""
         data = [self.item(item.row(), self.COL_NAME).text() for item in self._ordered_selects]
         if len(data) != 2:
@@ -180,11 +210,16 @@ class XyTable(DraggableSignalsTable, ContextMenuSignalsTable, HasRegionSignalsTa
                 self, "Error", f"Select two items for X-Y plotting, got {data}", QMessageBox.StandardButton.Ok
             )
             return None
+        xy_plot = self.create_xy()
+        xy_plot.add_xy(data[0], data[1])
+        return xy_plot
+
+    def create_xy(self) -> XyPlotWidget:
+        """Creates and opens an empty XY plot widget."""
         xy_plot = XyPlotWidget(self)
         xy_plot.show()
         xy_plot.set_range(self._range)
         self._xy_plots.append(xy_plot)  # need an active reference to prevent GC'ing
-        xy_plot.add_xy(data[0], data[1])
         return xy_plot
 
     def _on_closed_xy(self, closed: XyPlotWidget) -> None:

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -19,7 +19,7 @@ import pyqtgraph as pg
 from PySide6 import QtGui
 from PySide6.QtCore import QSize
 from PySide6.QtGui import QAction, QColor, QDragMoveEvent, QDragLeaveEvent, QDropEvent
-from PySide6.QtWidgets import QMenu, QTableWidgetItem, QMessageBox
+from PySide6.QtWidgets import QMenu, QMessageBox
 from numpy import typing as npt
 
 from .multi_plot_widget import DragTargetOverlay

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -172,13 +172,11 @@ class XyTable(
     def _load_model(self, model: BaseTopModel) -> None:
         super()._load_model(model)
 
-        # remove all existing plots
-        for xy_plot in self._xy_plots:
+        for xy_plot in self._xy_plots:  # remove all existing plots
             xy_plot.close()
 
-        # create plots from model
         assert isinstance(model, XyTableStateModel)
-        for xy_data_items in model.xy_data_items:
+        for xy_data_items in model.xy_data_items:  # create plots from model
             xy_plot = self.create_xy()
             for xy_data_item in xy_data_items:
                 xy_plot.add_xy(*xy_data_item)

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -215,18 +215,18 @@ def test_plot_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 def test_plot_restore(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     model = cast(MultiPlotStateModel, plot._plots._dump_model([]))
     model.widget_data_items = [["0", "1", "2"]]
-    plot._plots._restore_model(model)
+    plot._plots._load_model(model)
     qtbot.waitUntil(lambda: plot._plots.count() == 1)
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 3
 
     model.widget_data_items = [["0"], ["2"]]
-    plot._plots._restore_model(model)
+    plot._plots._load_model(model)
     qtbot.waitUntil(lambda: plot._plots.count() == 2)
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 1
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(1)).getPlotItem()).listDataItems()) == 1
 
     model.widget_data_items = []  # test empty case
-    plot._plots._restore_model(model)
+    plot._plots._load_model(model)
     qtbot.waitUntil(lambda: plot._plots.count() == 1)  # should leave the empty widget intact
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 0
 

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -196,6 +196,16 @@ def test_plot_remove(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     )
 
 
+def test_plot_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    qtbot.waitUntil(lambda: plot._plots._dump_model([]).widget_data_items == [["0"], ["1"], ["2"]])
+
+    plot._plots._merge_data_into_item(["0"], 1)  # merge
+    qtbot.waitUntil(lambda: plot._plots._dump_model([]).widget_data_items == [["1", "0"], ["2"]])
+
+    plot._plots._merge_data_into_item(["2"], 0)  # merge
+    qtbot.waitUntil(lambda: plot._plots._dump_model([]).widget_data_items == [["1", "0", "2"]])
+
+
 def test_no_excessive_plots(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     # check that the default limit for plot instantiation works
     plot._set_data_items(

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -197,17 +197,23 @@ def test_plot_remove(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
 
 def test_plot_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    qtbot.waitUntil(lambda: plot._plots._dump_model([]).widget_data_items == [["0"], ["1"], ["2"]])
+    qtbot.waitUntil(
+        lambda: cast(MultiPlotStateModel, plot._plots._dump_model([])).widget_data_items == [["0"], ["1"], ["2"]]
+    )
 
     plot._plots._merge_data_into_item(["0"], 1)  # merge
-    qtbot.waitUntil(lambda: plot._plots._dump_model([]).widget_data_items == [["1", "0"], ["2"]])
+    qtbot.waitUntil(
+        lambda: cast(MultiPlotStateModel, plot._plots._dump_model([])).widget_data_items == [["1", "0"], ["2"]]
+    )
 
     plot._plots._merge_data_into_item(["2"], 0)  # merge
-    qtbot.waitUntil(lambda: plot._plots._dump_model([]).widget_data_items == [["1", "0", "2"]])
+    qtbot.waitUntil(
+        lambda: cast(MultiPlotStateModel, plot._plots._dump_model([])).widget_data_items == [["1", "0", "2"]]
+    )
 
 
 def test_plot_restore(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    model = plot._plots._dump_model([])
+    model = cast(MultiPlotStateModel, plot._plots._dump_model([]))
     model.widget_data_items = [["0", "1", "2"]]
     plot._plots._restore_model(model)
     qtbot.waitUntil(lambda: plot._plots.count() == 1)

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -249,60 +249,6 @@ def test_no_excessive_plots(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 1
 
 
-def test_linked_live_cursor(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    """This (and subsequent) tests use internal APIs to set cursor positions and whatnot
-    because these APIs are much more reliable than using QtBot mouse actions."""
-    for i in range(3):
-        assert plot_item(plot, i).hover_cursor is None  # verify initial state
-
-    plot_item(plot, 0).set_live_cursor(0.1)
-    qtbot.waitUntil(lambda: not_none(plot_item(plot, 1).hover_cursor).x() == 0.1)
-    assert not_none(plot_item(plot, 2).hover_cursor).x() == 0.1
-
-    plot_item(plot, 1).set_live_cursor(None)
-    qtbot.waitUntil(lambda: plot_item(plot, 0).hover_cursor is None)
-    assert plot_item(plot, 2).hover_cursor is None
-
-
-def test_linked_region(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    for i in range(3):
-        assert plot_item(plot, i).cursor is None  # verify initial state
-        assert plot_item(plot, i).cursor_range is None
-
-    plot_item(plot, 0).set_region((0.1, 1.5))
-    qtbot.waitUntil(lambda: not_none(plot_item(plot, 1).cursor_range).getRegion() == (0.1, 1.5))
-    assert not_none(plot_item(plot, 2).cursor_range).getRegion() == (0.1, 1.5)
-    for i in range(3):
-        assert plot_item(plot, i).cursor is None
-
-    plot_item(plot, 1).set_region(1.0)
-    qtbot.waitUntil(lambda: not_none(plot_item(plot, 0).cursor).x() == 1.0)
-    assert not_none(plot_item(plot, 2).cursor).x() == 1.0
-    for i in range(3):
-        assert plot_item(plot, i).cursor_range is None
-
-
-def test_linked_pois(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    for i in range(3):
-        assert not plot_item(plot, i).pois  # verify initial state
-
-    plot_item(plot, 0).set_pois([0.1, 1.5])
-    qtbot.waitUntil(lambda: [poi.x() for poi in plot_item(plot, 1).pois] == [0.1, 1.5])
-    assert [poi.x() for poi in plot_item(plot, 2).pois] == [0.1, 1.5]
-
-
-def test_linked_drag_cursor(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    for i in range(3):
-        assert plot_item(plot, i).drag_cursor is None  # verify initial state
-
-    plot_item(plot, 0).set_drag_cursor(0.2)
-    qtbot.waitUntil(
-        lambda: plot_item(plot, 1).drag_cursor is not None and plot_item(plot, 1).drag_cursor.pos().x() == 0.2
-    )
-    assert plot_item(plot, 1).drag_cursor.pos().x() == 0.2
-    assert plot_item(plot, 2).drag_cursor.pos().x() == 0.2
-
-
 def test_export_csv(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     out_io = StringIO()
     plot._write_csv(out_io)

--- a/tests/test_linked_plot.py
+++ b/tests/test_linked_plot.py
@@ -98,6 +98,25 @@ def test_linked_pois(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     assert [poi.x() for poi in plot_item(plot, 2).pois] == [0.1, 1.5]
 
 
+def test_pois_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_model([])).pois == [])
+
+    plot_item(plot, 0).set_pois([0.1, 1.5])
+    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_model([])).pois == [0.1, 1.5])
+
+
+def test_pois_restore(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    model = cast(LinkedMultiPlotStateModel, plot._plots._dump_model([]))
+
+    model.pois = [0.1, 1.5]
+    plot._plots._restore_model(model)
+    qtbot.waitUntil(lambda: [poi.x() for poi in plot_item(plot, 1).pois] == [0.1, 1.5])
+
+    model.pois = []
+    plot._plots._restore_model(model)
+    qtbot.waitUntil(lambda: [poi.x() for poi in plot_item(plot, 1).pois] == [])
+
+
 def test_linked_drag_cursor(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     for i in range(3):
         assert plot_item(plot, i).drag_cursor is None  # verify initial state

--- a/tests/test_linked_plot.py
+++ b/tests/test_linked_plot.py
@@ -11,9 +11,11 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+from typing import cast
 
 from pytestqt.qtbot import QtBot
 
+from pyqtgraph_scope_plots.multi_plot_widget import LinkedMultiPlotStateModel
 from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
 from pyqtgraph_scope_plots.util import not_none
 from .test_base_plot import plot_item, plot
@@ -53,13 +55,13 @@ def test_linked_region(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
 
 def test_region_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    qtbot.waitUntil(lambda: plot._plots._dump_model([]).region is None)
+    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_model([])).region is None)
 
     plot_item(plot, 0).set_region((0.1, 1.5))
-    qtbot.waitUntil(lambda: plot._plots._dump_model([]).region == (0.1, 1.5))
+    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_model([])).region == (0.1, 1.5))
 
     plot_item(plot, 1).set_region(1.0)
-    qtbot.waitUntil(lambda: plot._plots._dump_model([]).region == 1.0)
+    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_model([])).region == 1.0)
 
 
 def test_linked_pois(qtbot: QtBot, plot: PlotsTableWidget) -> None:

--- a/tests/test_linked_plot.py
+++ b/tests/test_linked_plot.py
@@ -64,6 +64,31 @@ def test_region_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_model([])).region == 1.0)
 
 
+def test_region_restore(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    model = cast(LinkedMultiPlotStateModel, plot._plots._dump_model([]))
+
+    model.region = (0.1, 1.5)
+    plot._plots._restore_model(model)
+    qtbot.waitUntil(lambda: not_none(plot_item(plot, 1).cursor_range).getRegion() == (0.1, 1.5))
+    for i in range(3):
+        assert not_none(plot_item(plot, i).cursor_range).getRegion() == (0.1, 1.5)
+        assert plot_item(plot, i).cursor is None
+
+    model.region = 1.0
+    plot._plots._restore_model(model)
+    qtbot.waitUntil(lambda: not_none(plot_item(plot, 0).cursor).x() == 1.0)
+    for i in range(3):
+        assert plot_item(plot, i).cursor_range is None
+        assert not_none(plot_item(plot, i).cursor).x() == 1.0
+
+    model.region = None
+    plot._plots._restore_model(model)
+    qtbot.waitUntil(lambda: plot_item(plot, 1).cursor is None)
+    for i in range(3):
+        assert plot_item(plot, i).cursor is None
+        assert plot_item(plot, i).cursor_range is None
+
+
 def test_linked_pois(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     for i in range(3):
         assert not plot_item(plot, i).pois  # verify initial state

--- a/tests/test_linked_plot.py
+++ b/tests/test_linked_plot.py
@@ -1,0 +1,83 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from pytestqt.qtbot import QtBot
+
+from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
+from pyqtgraph_scope_plots.util import not_none
+from .test_base_plot import plot_item, plot
+
+
+def test_linked_live_cursor(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    """This (and subsequent) tests use internal APIs to set cursor positions and whatnot
+    because these APIs are much more reliable than using QtBot mouse actions."""
+    for i in range(3):
+        assert plot_item(plot, i).hover_cursor is None  # verify initial state
+
+    plot_item(plot, 0).set_live_cursor(0.1)
+    qtbot.waitUntil(lambda: not_none(plot_item(plot, 1).hover_cursor).x() == 0.1)
+    assert not_none(plot_item(plot, 2).hover_cursor).x() == 0.1
+
+    plot_item(plot, 1).set_live_cursor(None)
+    qtbot.waitUntil(lambda: plot_item(plot, 0).hover_cursor is None)
+    assert plot_item(plot, 2).hover_cursor is None
+
+
+def test_linked_region(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    for i in range(3):
+        assert plot_item(plot, i).cursor is None  # verify initial state
+        assert plot_item(plot, i).cursor_range is None
+
+    plot_item(plot, 0).set_region((0.1, 1.5))
+    qtbot.waitUntil(lambda: not_none(plot_item(plot, 1).cursor_range).getRegion() == (0.1, 1.5))
+    assert not_none(plot_item(plot, 2).cursor_range).getRegion() == (0.1, 1.5)
+    for i in range(3):
+        assert plot_item(plot, i).cursor is None
+
+    plot_item(plot, 1).set_region(1.0)
+    qtbot.waitUntil(lambda: not_none(plot_item(plot, 0).cursor).x() == 1.0)
+    assert not_none(plot_item(plot, 2).cursor).x() == 1.0
+    for i in range(3):
+        assert plot_item(plot, i).cursor_range is None
+
+
+def test_region_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    qtbot.waitUntil(lambda: plot._plots._dump_model([]).region is None)
+
+    plot_item(plot, 0).set_region((0.1, 1.5))
+    qtbot.waitUntil(lambda: plot._plots._dump_model([]).region == (0.1, 1.5))
+
+    plot_item(plot, 1).set_region(1.0)
+    qtbot.waitUntil(lambda: plot._plots._dump_model([]).region == 1.0)
+
+
+def test_linked_pois(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    for i in range(3):
+        assert not plot_item(plot, i).pois  # verify initial state
+
+    plot_item(plot, 0).set_pois([0.1, 1.5])
+    qtbot.waitUntil(lambda: [poi.x() for poi in plot_item(plot, 1).pois] == [0.1, 1.5])
+    assert [poi.x() for poi in plot_item(plot, 2).pois] == [0.1, 1.5]
+
+
+def test_linked_drag_cursor(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    for i in range(3):
+        assert plot_item(plot, i).drag_cursor is None  # verify initial state
+
+    plot_item(plot, 0).set_drag_cursor(0.2)
+    qtbot.waitUntil(
+        lambda: plot_item(plot, 1).drag_cursor is not None and plot_item(plot, 1).drag_cursor.pos().x() == 0.2
+    )
+    assert plot_item(plot, 1).drag_cursor.pos().x() == 0.2
+    assert plot_item(plot, 2).drag_cursor.pos().x() == 0.2

--- a/tests/test_linked_plot.py
+++ b/tests/test_linked_plot.py
@@ -68,21 +68,21 @@ def test_region_restore(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     model = cast(LinkedMultiPlotStateModel, plot._plots._dump_model([]))
 
     model.region = (0.1, 1.5)
-    plot._plots._restore_model(model)
+    plot._plots._load_model(model)
     qtbot.waitUntil(lambda: not_none(plot_item(plot, 1).cursor_range).getRegion() == (0.1, 1.5))
     for i in range(3):
         assert not_none(plot_item(plot, i).cursor_range).getRegion() == (0.1, 1.5)
         assert plot_item(plot, i).cursor is None
 
     model.region = 1.0
-    plot._plots._restore_model(model)
+    plot._plots._load_model(model)
     qtbot.waitUntil(lambda: not_none(plot_item(plot, 0).cursor).x() == 1.0)
     for i in range(3):
         assert plot_item(plot, i).cursor_range is None
         assert not_none(plot_item(plot, i).cursor).x() == 1.0
 
     model.region = None
-    plot._plots._restore_model(model)
+    plot._plots._load_model(model)
     qtbot.waitUntil(lambda: plot_item(plot, 1).cursor is None)
     for i in range(3):
         assert plot_item(plot, i).cursor is None
@@ -109,11 +109,11 @@ def test_pois_restore(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     model = cast(LinkedMultiPlotStateModel, plot._plots._dump_model([]))
 
     model.pois = [0.1, 1.5]
-    plot._plots._restore_model(model)
+    plot._plots._load_model(model)
     qtbot.waitUntil(lambda: [poi.x() for poi in plot_item(plot, 1).pois] == [0.1, 1.5])
 
     model.pois = []
-    plot._plots._restore_model(model)
+    plot._plots._load_model(model)
     qtbot.waitUntil(lambda: [poi.x() for poi in plot_item(plot, 1).pois] == [])
 
 

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -3,7 +3,7 @@ from typing import Optional, List, Tuple
 from pydantic import BaseModel
 from pydantic._internal._model_construction import ModelMetaclass
 
-from pyqtgraph_scope_plots.save_restore_model import DataTopModel, BaseTopModel, HasSaveRestoreModel
+from pyqtgraph_scope_plots.save_restore_model import DataTopModel, BaseTopModel, HasSaveLoadConfig
 
 
 class DataModelSub1(DataTopModel):
@@ -26,12 +26,9 @@ class BaseModelSub2(BaseTopModel):
     inner: InnerModel = InnerModel()
 
 
-class SaveRestoreSub(HasSaveRestoreModel):
-    def _get_model_bases(
-        self, data_bases: List[ModelMetaclass], misc_bases: List[ModelMetaclass]
-    ) -> Tuple[List[ModelMetaclass], List[ModelMetaclass]]:
-        data_bases, misc_bases = super()._get_model_bases(data_bases, misc_bases)
-        return [DataModelSub1, DataModelSub2] + data_bases, [BaseModelSub1, BaseModelSub2] + misc_bases
+class SaveRestoreSub(HasSaveLoadConfig):
+    TOP_MODEL_BASES = [BaseModelSub1, BaseModelSub2]
+    DATA_MODEL_BASES = [DataModelSub1, DataModelSub2]
 
     def _write_model(self, model: BaseTopModel) -> None:
         super()._write_model(model)
@@ -44,8 +41,8 @@ class SaveRestoreSub(HasSaveRestoreModel):
         model.base_field1 = 2.0
         model.inner.a_field = "a"
 
-    def _restore_model(self, model: BaseTopModel) -> None:
-        super()._restore_model(model)
+    def _load_model(self, model: BaseTopModel) -> None:
+        super()._load_model(model)
 
 
 def test_save_model() -> None:

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -1,7 +1,6 @@
-from typing import Optional, List, Tuple
+from typing import Optional
 
 from pydantic import BaseModel
-from pydantic._internal._model_construction import ModelMetaclass
 
 from pyqtgraph_scope_plots.save_restore_model import DataTopModel, BaseTopModel, HasSaveLoadConfig
 

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -32,6 +32,8 @@ class SaveRestoreSub(HasSaveRestoreModel):
         return [DataModelSub1, DataModelSub2] + data_bases, [BaseModelSub1, BaseModelSub2] + misc_bases
 
     def _save_model(self, model: BaseTopModel) -> None:
+        super()._save_model(model)
+
         assert isinstance(model, BaseModelSub2) and isinstance(model, BaseModelSub2)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, DataModelSub1) and isinstance(data_model, DataModelSub2)
@@ -41,7 +43,7 @@ class SaveRestoreSub(HasSaveRestoreModel):
         model.inner.a_field = "a"
 
     def _restore_model(self, model: BaseTopModel) -> None:
-        pass
+        super()._restore_model(model)
 
 
 def test_save_model() -> None:

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -1,4 +1,4 @@
-from typing import Optional, Type, List, Tuple
+from typing import Optional, List, Tuple
 
 from pydantic import BaseModel
 from pydantic._internal._model_construction import ModelMetaclass

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -1,0 +1,52 @@
+from typing import Optional, Type, List, Tuple
+
+from pydantic import BaseModel
+
+from pyqtgraph_scope_plots.save_restore_model import DataTopModel, BaseTopModel, HasSaveRestoreModel
+
+
+class DataModelSub1(DataTopModel):
+    field1: int = 1
+
+
+class DataModelSub2(DataTopModel):
+    field2: Optional[str] = None
+
+
+class BaseModelSub1(BaseTopModel):
+    base_field1: float = 4.2
+
+
+class InnerModel(BaseModel):
+    a_field: str = "in"
+
+
+class BaseModelSub2(BaseTopModel):
+    inner: InnerModel = InnerModel()
+
+
+class SaveRestoreSub(HasSaveRestoreModel):
+    def _get_model_bases(
+        self, data_bases: List[Type[BaseModel]], misc_bases: List[Type[BaseModel]]
+    ) -> Tuple[List[Type[BaseModel]], List[Type[BaseModel]]]:
+        return [DataModelSub1, DataModelSub2] + data_bases, [BaseModelSub1, BaseModelSub2] + misc_bases
+
+    def _save_model(self, model: BaseTopModel) -> None:
+        pass
+
+    def _restore_model(self, model: BaseTopModel) -> None:
+        pass
+
+
+def test_save_model() -> None:
+    """Tests composition of the save model"""
+    instance = SaveRestoreSub()
+    skeleton = instance._create_skeleton_model(["data1", "data2", "data3"])
+
+    assert skeleton.data["data1"].field1 == 1
+    assert skeleton.data["data1"].field2 is None
+    assert skeleton.data["data2"].field1 == 1
+    assert skeleton.data["data3"].field1 == 1
+
+    assert skeleton.base_field1 == 4.2
+    assert skeleton.inner.a_field == "in"

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -32,7 +32,13 @@ class SaveRestoreSub(HasSaveRestoreModel):
         return [DataModelSub1, DataModelSub2] + data_bases, [BaseModelSub1, BaseModelSub2] + misc_bases
 
     def _save_model(self, model: BaseTopModel) -> None:
-        pass
+        assert isinstance(model, BaseModelSub2) and isinstance(model, BaseModelSub2)
+        for data_name, data_model in model.data.items():
+            assert isinstance(data_model, DataModelSub1) and isinstance(data_model, DataModelSub2)
+            data_model.field2 = data_name
+
+        model.base_field1 = 2.0
+        model.inner.a_field = "a"
 
     def _restore_model(self, model: BaseTopModel) -> None:
         pass
@@ -50,3 +56,10 @@ def test_save_model() -> None:
 
     assert skeleton.base_field1 == 4.2
     assert skeleton.inner.a_field == "in"
+
+    instance._save_model(skeleton)
+    assert skeleton.base_field1 == 2.0
+    assert skeleton.inner.a_field == "a"
+    assert skeleton.data["data1"].field2 == "data1"
+    assert skeleton.data["data2"].field2 == "data2"
+    assert skeleton.data["data3"].field2 == "data3"

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 from typing import Optional
 
 from pydantic import BaseModel

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from typing import Optional
+from typing import Optional, Iterable, cast, Dict
 
 from pydantic import BaseModel
 
@@ -43,25 +43,45 @@ class SaveRestoreSub(HasSaveLoadConfig):
     TOP_MODEL_BASES = [BaseModelSub1, BaseModelSub2]
     DATA_MODEL_BASES = [DataModelSub1, DataModelSub2]
 
+    def __init__(self, data_names: Iterable[str]):
+        self.data_field1s = {}
+        self.data_field2s: Dict[str, Optional[str]] = {}
+        for data_name in data_names:
+            self.data_field1s[data_name] = 1
+            self.data_field2s[data_name] = data_name
+
+        self.base_field1 = 2.0
+        self.inner_a_field = "a"
+
     def _write_model(self, model: BaseTopModel) -> None:
         super()._write_model(model)
 
         assert isinstance(model, BaseModelSub1) and isinstance(model, BaseModelSub2)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, DataModelSub1) and isinstance(data_model, DataModelSub2)
-            data_model.field2 = data_name
+            data_model.field1 = self.data_field1s[data_name]
+            data_model.field2 = self.data_field2s[data_name]
 
-        model.base_field1 = 2.0
-        model.inner.a_field = "a"
+        model.base_field1 = self.base_field1
+        model.inner.a_field = self.inner_a_field
 
     def _load_model(self, model: BaseTopModel) -> None:
         super()._load_model(model)
 
+        assert isinstance(model, BaseModelSub1) and isinstance(model, BaseModelSub2)
+        for data_name, data_model in model.data.items():
+            assert isinstance(data_model, DataModelSub1) and isinstance(data_model, DataModelSub2)
+            self.data_field1s[data_name] = data_model.field1
+            self.data_field2s[data_name] = data_model.field2
+
+        self.base_field1 = model.base_field1
+        self.inner_a_field = model.inner.a_field
+
 
 def test_save_model() -> None:
     """Tests composition of the save model"""
-    instance = SaveRestoreSub()
-    skeleton = instance._create_skeleton_model(["data1", "data2", "data3"])
+    instance = SaveRestoreSub(["data1", "data2", "data3"])
+    skeleton = instance._create_skeleton_model(instance.data_field1s.keys())
 
     assert isinstance(skeleton, BaseModelSub1) and isinstance(skeleton, BaseModelSub2)
     assert isinstance(skeleton.data["data1"], DataModelSub1) and isinstance(skeleton.data["data1"], DataModelSub2)
@@ -82,3 +102,16 @@ def test_save_model() -> None:
     assert skeleton.data["data1"].field2 == "data1"
     assert skeleton.data["data2"].field2 == "data2"
     assert skeleton.data["data3"].field2 == "data3"
+
+
+def test_load_model() -> None:
+    instance = SaveRestoreSub(["data1", "data2", "data3"])
+    model = instance._create_skeleton_model(instance.data_field1s.keys())
+    cast(DataModelSub2, model.data["data3"]).field2 = "quack"
+
+    instance._load_model(model)
+    assert instance.base_field1 == 4.2
+    assert instance.inner_a_field == "in"
+    assert instance.data_field2s["data1"] is None  # loaded with default value
+    assert instance.data_field2s["data2"] is None
+    assert instance.data_field2s["data3"] == "quack"

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -33,8 +33,8 @@ class SaveRestoreSub(HasSaveRestoreModel):
         data_bases, misc_bases = super()._get_model_bases(data_bases, misc_bases)
         return [DataModelSub1, DataModelSub2] + data_bases, [BaseModelSub1, BaseModelSub2] + misc_bases
 
-    def _save_model(self, model: BaseTopModel) -> None:
-        super()._save_model(model)
+    def _write_model(self, model: BaseTopModel) -> None:
+        super()._write_model(model)
 
         assert isinstance(model, BaseModelSub1) and isinstance(model, BaseModelSub2)
         for data_name, data_model in model.data.items():
@@ -66,7 +66,7 @@ def test_save_model() -> None:
     assert skeleton.base_field1 == 4.2
     assert skeleton.inner.a_field == "in"
 
-    instance._save_model(skeleton)
+    instance._write_model(skeleton)
     assert skeleton.base_field1 == 2.0
     assert skeleton.inner.a_field == "a"
     assert skeleton.data["data1"].field2 == "data1"

--- a/tests/test_transforms_timeshift_table.py
+++ b/tests/test_transforms_timeshift_table.py
@@ -193,7 +193,7 @@ def test_timeshift(qtbot: QtBot, timeshifts_table: TimeshiftSignalsTable) -> Non
 
 def test_timeshift_save(qtbot: QtBot, timeshifts_table: TimeshiftSignalsTable) -> None:
     qtbot.waitUntil(lambda: cast(TimeshiftDataStateModel, timeshifts_table._dump_model(["0"]).data["0"]).timeshift == 0)
-    timeshifts_table.set_timeshift(["0"], -0.5)  # test negative and noninteger
+    timeshifts_table.set_timeshift(["0"], -0.5)
     qtbot.waitUntil(
         lambda: cast(TimeshiftDataStateModel, timeshifts_table._dump_model(["0"]).data["0"]).timeshift == -0.5
     )

--- a/tests/test_transforms_timeshift_table.py
+++ b/tests/test_transforms_timeshift_table.py
@@ -182,8 +182,13 @@ def test_timeshift(qtbot: QtBot, timeshifts_table: TimeshiftSignalsTable) -> Non
     qtbot.waitUntil(lambda: timeshifts_table.apply_timeshifts("0", DATA).tolist() == [0.0, 0.1, 1.0, 2.0])
     timeshifts_table.set_timeshift(["0"], 1)
     qtbot.waitUntil(lambda: timeshifts_table.apply_timeshifts("0", DATA).tolist() == [1.0, 1.1, 2.0, 3.0])
+    assert timeshifts_table.item(0, timeshifts_table.COL_TIMESHIFT).text() == "1"
     timeshifts_table.set_timeshift(["0"], -0.5)  # test negative and noninteger
     qtbot.waitUntil(lambda: timeshifts_table.apply_timeshifts("0", DATA).tolist() == [-0.5, -0.4, 0.5, 1.5])
+    assert timeshifts_table.item(0, timeshifts_table.COL_TIMESHIFT).text() == "-0.5"
+    timeshifts_table.set_timeshift(["0"], 0)  # revert to empty
+    qtbot.waitUntil(lambda: timeshifts_table.apply_timeshifts("0", DATA).tolist() == [0.0, 0.1, 1.0, 2.0])
+    assert timeshifts_table.item(0, timeshifts_table.COL_TIMESHIFT).text() == ""
 
 
 def test_timeshift_save(qtbot: QtBot, timeshifts_table: TimeshiftSignalsTable) -> None:

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -11,6 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+from typing import cast
 
 import pytest
 from PySide6.QtGui import QColor
@@ -18,6 +19,7 @@ from pytestqt.qtbot import QtBot
 
 from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
+from pyqtgraph_scope_plots.xy_plot_table import XyTableStateModel
 
 
 @pytest.fixture()
@@ -45,18 +47,18 @@ def plot(qtbot: QtBot) -> PlotsTableWidget:
     return plot
 
 
-def test_xy_create(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+def test_xy_create_ui(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     # test that xy creation doesn't error out and follows the user order
     plot._table.item(1, 0).setSelected(True)
     plot._table.item(0, 0).setSelected(True)
-    xy_plot = plot._table._on_xy()
+    xy_plot = plot._table._on_create_xy()
     assert xy_plot is not None
     assert xy_plot._xys == [("1", "0")]
 
     plot._table.clearSelection()
     plot._table.item(0, 0).setSelected(True)
     plot._table.item(1, 0).setSelected(True)
-    xy_plot = plot._table._on_xy()
+    xy_plot = plot._table._on_create_xy()
     assert xy_plot is not None
     assert xy_plot._xys == [("0", "1")]
 
@@ -64,13 +66,27 @@ def test_xy_create(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
 
 def test_xy_offset(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    plot._table.item(0, 0).setSelected(True)
-    plot._table.item(2, 0).setSelected(True)
-    xy_plot = plot._table._on_xy()
-    assert xy_plot is not None
-    assert xy_plot._xys == [("0", "2")]
-
+    xy_plot = plot._table.create_xy()
+    xy_plot.add_xy("0", "2")
     xy_plot.add_xy("2", "0")
     assert xy_plot._xys == [("0", "2"), ("2", "0")]
 
-    qtbot.wait(10)  # wait for rendering to happen
+    qtbot.wait(10)  # wait for rendering to happen to ensure it doesn't error
+
+
+def test_xy_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    xy_plot = plot._table.create_xy()
+    xy_plot.add_xy("0", "1")
+    xy_plot.add_xy("1", "0")
+    qtbot.waitUntil(
+        lambda: cast(XyTableStateModel, plot._table._dump_model([])).xy_data_items == [[("0", "1"), ("1", "0")]]
+    )
+
+
+def test_xy_load(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    model = cast(XyTableStateModel, plot._table._dump_model([]))
+
+    model.xy_data_items = [[("1", "0")]]
+    plot._table._load_model(model)
+    qtbot.waitUntil(lambda: len(plot._table._xy_plots) == 1)
+    assert plot._table._xy_plots[0]._xys == [("1", "0")]


### PR DESCRIPTION
Adds infrastructure for saving / loading config to a Pydantic model, plus implementations for save / load for major mixins. Configs are structured as data (on a per-data-item basis) and top (on a per-config-file basis). Adds basic save-load config to the CSV viewer example using YAML files.

Architecturally, this adds a HasSaveLoadModel mixin, which subclasses can define a class-level DATA_MODEL_BASES and TOP_MODEL_BASES. During save or load, the combined Pydantic class is dynamically generated by aggregating all the DATA_MODEL_BASES and TOP_MODEL_BASES of subclasses. This allows save / restore code to be modularized on a per-mixin basis, while using Pydantic Model fragments for type-safety and validation.

Other changes:
- Improve dependencies with >= versioning
- Timeshift = 0 now shows up as empty on the signals table
- Split linked-plot tests into its own file

Future work:
- Add and implement style recommendations to the HasSaveLoadModel. In particular, subclasses should define and handle an explicit None value, which means to not touch some setting. Save should always generate values, but the user can delete lines to ignore certain configs when loading.
- CSV viewer should save CSV files loaded, and automatically re-load then, using relative-path of the YAML file.
- Some way to surface errors during the loading process.