### PR TITLE
Save and load loaded CSV files in the config

### DIFF
--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -415,10 +415,10 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
 
         return self
 
-    def _on_save_config(self) -> Optional[CsvLoaderStateModel]:
+    def _on_save_config(self) -> None:
         filename, _ = QFileDialog.getSaveFileName(None, "Save config", filter="YAML files (*.yml)")
         if not filename:  # nothing selected, user canceled
-            return None
+            return
         model = self._do_save_config(filename)
         with open(filename, "w") as f:
             f.write(yaml.dump(model.model_dump(), sort_keys=False))
@@ -437,11 +437,12 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
             config_dir = os.path.dirname(filename)
             try:
                 all_commonpath = os.path.commonpath([csvs_commonpath, config_dir])
-            except ValueError:
-                all_commonpath = ""  # eg, paths not on same drive
+            except ValueError:  # eg, paths not on same drive
+                all_commonpath = None
             # TODO there should be some indication to the user about whether it's saving
             # in relpath or abspath mode, probably in the file dialog, and an explanation of why it matters
-            if os.path.abspath(config_dir) == os.path.abspath(all_commonpath):  # save as relpath, configs above CSVs
+            if all_commonpath is not None and os.path.abspath(config_dir) == os.path.abspath(all_commonpath):
+                # save as relpath, configs above CSVs
                 model.csv_files = [
                     os.path.relpath(csv_filename, config_dir) for csv_filename in self._csv_data_items.keys()
                 ]
@@ -461,7 +462,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         assert isinstance(model, CsvLoaderStateModel)
         self._do_load_config(filename, model)
 
-    def _do_load_config(self, filename: str, model: CsvLoaderStateModel):
+    def _do_load_config(self, filename: str, model: CsvLoaderStateModel) -> None:
         if model.csv_files is not None:
             missing_csv_files = []
             found_csv_files = []

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -340,12 +340,18 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
             self._load_csv(files_to_load, colnames=data_items_to_load, append=True)
 
     def _load_csv(
-        self, csv_filepaths: List[str], append: bool = False, colnames: Optional[Iterable[str]] = None
+        self,
+        csv_filepaths: List[str],
+        append: bool = False,
+        colnames: Optional[Iterable[str]] = None,
+        update: bool = True,
     ) -> "CsvLoaderPlotsTableWidget":
         """Loads CSV files into the current window.
         If append is true, preserves the existing data / metadata.
         If colnames is not None, reads the specified column names from the file. These must already be in the dataset.
         Items in colnames but not in the file are read as an empty table
+
+        If update is disabled, only sets the self._data internal variable to allow for a later bulk update
         """
         # prepare data structures
         data_type_dict: Dict[str, MultiPlotWidget.PlotType] = {}  # col header -> plot type IF NOT Default
@@ -401,7 +407,10 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         if colnames is None:  # colnames not None means update only
             data_items = [(name, int_color(i), data_type) for i, (name, data_type) in enumerate(data_type_dict.items())]
             self._set_data_items(data_items)
-        self._set_data(data_dict)
+        if update:
+            self._set_data(data_dict)
+        else:
+            self._data = data_dict
         self._csv_data_items = csv_data_items_dict
 
         return self
@@ -470,7 +479,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
                     f"Some CSV files not found: {', '.join(missing_csv_files)}",
                     QMessageBox.StandardButton.Ok,
                 )
-            self._load_csv(found_csv_files)
+            self._load_csv(found_csv_files, update=False)
 
         data = self._data
         self._set_data({})  # blank the data while updates happen, for performance

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -419,6 +419,8 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
 
         config_dir = os.path.dirname(filename)
         all_commonpath = os.path.commonpath([csvs_commonpath, config_dir])
+        # TODO there should be some indication to the user about whether it's saving
+        # in relpath or abspath mode, probably in the file dialog, and an explanation of why it matters
         if os.path.abspath(config_dir) == os.path.abspath(all_commonpath):  # save as relpath, configs above CSVs
             model.csv_files = [
                 os.path.relpath(csv_filename, config_dir) for csv_filename in self._csv_data_items.keys()

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -136,7 +136,6 @@ class MultiPlotWidget(HasSaveLoadConfig, QSplitter):
             return
 
         self._plot_item_data = {}  # remove all existing plots
-        self._clean_plot_widgets()
 
         for plot_widget_model in model.plot_widgets:  # create plots from model
             if len(plot_widget_model.data_items) < 1:  # skip empty plots
@@ -159,6 +158,7 @@ class MultiPlotWidget(HasSaveLoadConfig, QSplitter):
                     x=model.x_range == "auto" or None, y=plot_widget_model.y_range == "auto" or None
                 )
 
+        self._clean_plot_widgets()
         self._check_create_default_plot()
         self._update_plots_x_axis()
         self._update_data_name_to_plot_item()

--- a/tests/test_csv_viewer.py
+++ b/tests/test_csv_viewer.py
@@ -66,3 +66,18 @@ def test_watch_stability(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
         mock_getmtime.return_value = mock_getmtime.return_value + 10  # reset the counter
         plot._watch_timer.timeout.emit()
         qtbot.waitUntil(lambda: mock_load_csv.called)  # check the load happens
+
+
+def test_save_model_csvs(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
+    # test saving in relpath mode
+
+    # test saving in abspath mode
+    pass
+
+
+def test_load_model_csvs(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
+    # test saving in relpath mode
+
+    # test saving in abspath mode
+    pass
+    # TODO measure impact of double-set_data and optionally optimize

--- a/tests/test_csv_viewer.py
+++ b/tests/test_csv_viewer.py
@@ -97,9 +97,13 @@ def test_load_model_csvs_relpath(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) 
     with mock.patch.object(CsvLoaderPlotsTableWidget, "_load_csv") as mock_load_csv:
         model.csv_files = [os.path.join("data", "test_csv_viewer_data.csv")]  # relpath
         plot._do_load_config(os.path.join(os.path.dirname(__file__), "config.yml"), model)
-        mock_load_csv.assert_called_with([os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv")])
+        mock_load_csv.assert_called_with(
+            [os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv")], update=False
+        )
 
     with mock.patch.object(CsvLoaderPlotsTableWidget, "_load_csv") as mock_load_csv:
         model.csv_files = [os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv")]  # abspath
         plot._do_load_config(os.path.join(os.path.dirname(__file__), "config.yml"), model)
-        mock_load_csv.assert_called_with([os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv")])
+        mock_load_csv.assert_called_with(
+            [os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv")], update=False
+        )

--- a/tests/test_csv_viewer.py
+++ b/tests/test_csv_viewer.py
@@ -69,15 +69,37 @@ def test_watch_stability(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
 
 
 def test_save_model_csvs(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
+    # test empty save
+    model = plot._do_save_config(os.path.join(os.path.dirname(__file__), "config.yml"))
+    assert model.csv_files == []  # relpath
+
+    plot._load_csv([os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv")])
+
     # test saving in relpath mode
+    model = plot._do_save_config(os.path.join(os.path.dirname(__file__), "config.yml"))
+    assert model.csv_files == [os.path.join("data", "test_csv_viewer_data.csv")]  # relpath
 
     # test saving in abspath mode
-    pass
+    model = plot._do_save_config("/config.yml")
+    assert model.csv_files == [
+        os.path.abspath(os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv"))
+    ]
 
 
-def test_load_model_csvs(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
-    # test saving in relpath mode
+def test_load_model_csvs_relpath(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
+    model = plot._do_save_config("/config.yml")
 
-    # test saving in abspath mode
-    pass
-    # TODO measure impact of double-set_data and optionally optimize
+    with mock.patch.object(CsvLoaderPlotsTableWidget, "_load_csv") as mock_load_csv:
+        model.csv_files = None
+        plot._do_load_config(os.path.join(os.path.dirname(__file__), "config.yml"), model)
+        mock_load_csv.assert_not_called()
+
+    with mock.patch.object(CsvLoaderPlotsTableWidget, "_load_csv") as mock_load_csv:
+        model.csv_files = [os.path.join("data", "test_csv_viewer_data.csv")]  # relpath
+        plot._do_load_config(os.path.join(os.path.dirname(__file__), "config.yml"), model)
+        mock_load_csv.assert_called_with([os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv")])
+
+    with mock.patch.object(CsvLoaderPlotsTableWidget, "_load_csv") as mock_load_csv:
+        model.csv_files = [os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv")]  # abspath
+        plot._do_load_config(os.path.join(os.path.dirname(__file__), "config.yml"), model)
+        mock_load_csv.assert_called_with([os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv")])

--- a/tests/test_csv_viewer.py
+++ b/tests/test_csv_viewer.py
@@ -80,7 +80,7 @@ def test_save_model_csvs(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
     assert model.csv_files == [os.path.join("data", "test_csv_viewer_data.csv")]  # relpath
 
     # test saving in abspath mode
-    model = plot._do_save_config("/config.yml")
+    model = plot._do_save_config("/lol/config.yml")
     assert model.csv_files == [
         os.path.abspath(os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv"))
     ]


### PR DESCRIPTION
Saves loaded CSV files as part of the config, and re-opens then when loading, if present. CSVs are saved as relative-path if the YAML is above the CSVs, otherwise saved as absolute-path.
