### PR TITLE
Add XY table, beginnings of refactor to make table subordinate to plots

### DIFF
--- a/pyqtgraph_scope_plots/animation_plot_table_widget.py
+++ b/pyqtgraph_scope_plots/animation_plot_table_widget.py
@@ -56,7 +56,9 @@ class AnimationPlotsTableWidget(PlotsTableWidget):
 
         capture_windows: List[QWidget] = [self._plots]
         if isinstance(self._table, XyTable):
-            capture_windows.extend(self._table._xy_plots)
+            for widget in self._table._xy_plots:
+                assert isinstance(widget, QWidget)
+                capture_windows.append(widget)
 
         images = []
         for i in range(frames_count):

--- a/pyqtgraph_scope_plots/csv/__main__.py
+++ b/pyqtgraph_scope_plots/csv/__main__.py
@@ -18,6 +18,7 @@ synthetic data and also can load CSVs."""
 import math
 
 import numpy as np
+from PySide6 import QtGui
 from PySide6.QtWidgets import QApplication
 
 from .csv_plots import CsvLoaderPlotsTableWidget
@@ -25,9 +26,15 @@ from ..multi_plot_widget import MultiPlotWidget
 from ..util import int_color
 
 
+class CsvLoaderPlotsTableWindow(CsvLoaderPlotsTableWidget):
+    def closeEvent(self, event: QtGui.QCloseEvent):
+        QApplication.closeAllWindows()
+        event.accept()
+
+
 if __name__ == "__main__":
     app = QApplication([])
-    plots = CsvLoaderPlotsTableWidget()
+    plots = CsvLoaderPlotsTableWindow()
     plots.resize(1200, 800)
 
     PTS_PER_CYCLE = 128

--- a/pyqtgraph_scope_plots/csv/__main__.py
+++ b/pyqtgraph_scope_plots/csv/__main__.py
@@ -27,7 +27,7 @@ from ..util import int_color
 
 
 class CsvLoaderPlotsTableWindow(CsvLoaderPlotsTableWidget):
-    def closeEvent(self, event: QtGui.QCloseEvent):
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:
         QApplication.closeAllWindows()
         event.accept()
 

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -413,8 +413,8 @@ class LinkedMultiPlotWidget(MultiPlotWidget, HasSaveLoadConfig):
             if plot_item is not sig_plot_item and isinstance(plot_item, LiveCursorPlot):
                 with QSignalBlocker(plot_item):
                     plot_item.set_live_cursor(position)
-        self.sigHoverCursorChanged.emit(position)
         self._last_hover = position
+        self.sigHoverCursorChanged.emit(position)
 
     def _on_region_change(
         self, sig_plot_item: Optional[pg.PlotItem], region: Optional[Union[float, Tuple[float, float]]]
@@ -424,8 +424,8 @@ class LinkedMultiPlotWidget(MultiPlotWidget, HasSaveLoadConfig):
             if plot_item is not sig_plot_item and isinstance(plot_item, RegionPlot):
                 with QSignalBlocker(plot_item):
                     plot_item.set_region(region)
-        self.sigCursorRangeChanged.emit(region)
         self._last_region = region
+        self.sigCursorRangeChanged.emit(region)
 
     def _on_poi_change(self, sig_plot_item: Optional[pg.PlotItem], pois: List[float]) -> None:
         """Propagates POI change to all plots, excluding signal source sig_plot_item if specified."""
@@ -433,8 +433,8 @@ class LinkedMultiPlotWidget(MultiPlotWidget, HasSaveLoadConfig):
             if plot_item is not sig_plot_item and isinstance(plot_item, PointsOfInterestPlot):
                 with QSignalBlocker(plot_item):
                     plot_item.set_pois(pois)
-        self.sigPoiChanged.emit(pois)
         self._last_pois = pois
+        self.sigPoiChanged.emit(pois)
 
     def create_drag_cursor(self, pos: float) -> None:
         for plot_item, _ in self._plot_item_data.items():
@@ -448,8 +448,8 @@ class LinkedMultiPlotWidget(MultiPlotWidget, HasSaveLoadConfig):
             if plot_item is not sig_plot_item and isinstance(plot_item, DraggableCursorPlot):
                 with QSignalBlocker(plot_item):
                     plot_item.set_drag_cursor(pos)
-        self.sigDragCursorChanged.emit(pos)
         self._last_drag_cursor = pos
+        self.sigDragCursorChanged.emit(pos)
 
     def _on_drag_cursor_clear(self, sig_plot_item: pg.PlotItem) -> None:
         """Propagates drag cursor removal to all plots, excluding signal source sig_plot_item if specified."""
@@ -457,8 +457,8 @@ class LinkedMultiPlotWidget(MultiPlotWidget, HasSaveLoadConfig):
             if plot_item is not sig_plot_item and isinstance(plot_item, DraggableCursorPlot):
                 with QSignalBlocker(plot_item):
                     plot_item.set_drag_cursor(None)
-        self.sigDragCursorCleared.emit()
         self._last_drag_cursor = None
+        self.sigDragCursorCleared.emit()
 
 
 class DragTargetOverlay(QWidget):

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -26,7 +26,6 @@ from pydantic import BaseModel
 
 from .enum_waveform_plotitem import EnumWaveformPlot
 from .interactivity_mixins import PointsOfInterestPlot, RegionPlot, LiveCursorPlot, DraggableCursorPlot
-from .signals_table import DraggableSignalsTable
 from .save_restore_model import HasSaveLoadConfig, BaseTopModel
 
 
@@ -545,6 +544,8 @@ class DroppableMultiPlotWidget(MultiPlotWidget):
         self._update_plots()
 
     def dragEnterEvent(self, event: QDragMoveEvent) -> None:
+        from .signals_table import DraggableSignalsTable
+
         if not event.mimeData().data(DraggableSignalsTable.DRAG_MIME_TYPE):  # check for right type
             return
         event.accept()
@@ -602,6 +603,8 @@ class DroppableMultiPlotWidget(MultiPlotWidget):
         self._clear_drag_overlays()
 
     def dropEvent(self, event: QDropEvent) -> None:
+        from .signals_table import DraggableSignalsTable
+
         self._clear_drag_overlays()
 
         data = event.mimeData().data(DraggableSignalsTable.DRAG_MIME_TYPE)

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -71,6 +71,8 @@ class MultiPlotWidget(HasSaveLoadConfig, QSplitter):
     sigDragCursorChanged = Signal(float)  # x-position
     sigDragCursorCleared = Signal()
 
+    sigDataUpdated = Signal()  # called when new plot data is available
+
     TOP_MODEL_BASES = [MultiPlotStateModel]
 
     def __init__(
@@ -85,7 +87,7 @@ class MultiPlotWidget(HasSaveLoadConfig, QSplitter):
         self._new_data_action = new_data_action
 
         self._data_items: Mapping[str, Tuple[QColor, MultiPlotWidget.PlotType]] = {}  # ordered
-        self._data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = {}
+        self._data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = {}  # post-transforms
 
         self.setOrientation(Qt.Orientation.Vertical)
         default_plot_item = self._init_plot_item(self._create_plot_item(self.PlotType.DEFAULT))
@@ -324,6 +326,7 @@ class MultiPlotWidget(HasSaveLoadConfig, QSplitter):
         set_data_items, missing items will log an error."""
         self._data = {name: (np.array(xs), np.array(ys)) for name, (xs, ys) in data.items()}
         self._update_plots()
+        self.sigDataUpdated.emit()
 
     def _update_plots(self) -> None:
         for plot_item, data_names in self._plot_item_data.items():

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -71,6 +71,7 @@ class MultiPlotWidget(HasSaveLoadConfig, QSplitter):
     sigDragCursorChanged = Signal(float)  # x-position
     sigDragCursorCleared = Signal()
 
+    sigDataItemsUpdated = Signal()  # called when new plot data items are set
     sigDataUpdated = Signal()  # called when new plot data is available
 
     TOP_MODEL_BASES = [MultiPlotStateModel]
@@ -320,6 +321,7 @@ class MultiPlotWidget(HasSaveLoadConfig, QSplitter):
         self._check_create_default_plot()
         self._update_data_name_to_plot_item()
         self._update_plots_x_axis()
+        self.sigDataItemsUpdated.emit()
 
     def set_data(self, data: Mapping[str, Tuple[np.typing.ArrayLike, np.typing.ArrayLike]]) -> None:
         """Sets the data to be plotted as data name -> (xs, ys). Data names must have been previously set with

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -38,13 +38,6 @@ class PlotsTableWidget(QSplitter):
     class PlotsTableSignalsTable(XyTable, DraggableSignalsTable, TransformsSignalsTable, StatsSignalsTable):
         """SignalsTable used in PlotsTableWidget with required mixins."""
 
-        def __init__(self, plots: MultiPlotWidget, *args: Any, **kwargs: Any) -> None:
-            self._plots = plots
-            super().__init__(*args, **kwargs)
-
-        def _render_value(self, data_name: str, value: float) -> str:
-            return self._plots.render_value(data_name, value)
-
     def _make_plots(self) -> PlotsTableMultiPlots:
         """Returns the plots widget. Optionally override to use a different plots widget."""
         return self.PlotsTableMultiPlots()

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -25,6 +25,7 @@ from PySide6.QtGui import QColor, Qt, QAction, QDrag, QPixmap, QMouseEvent
 from PySide6.QtWidgets import QTableWidgetItem, QTableWidget, QHeaderView, QMenu, QLabel, QColorDialog
 
 from .cache_dict import IdentityCacheDict
+from .multi_plot_widget import MultiPlotWidget
 from .save_restore_model import HasSaveLoadConfig, DataTopModel, BaseTopModel
 from .util import not_none
 
@@ -74,8 +75,9 @@ class SignalsTable(QTableWidget):
         Subclasses should override this (including a super() call)"""
         self.setHorizontalHeaderItem(self.COL_NAME, QTableWidgetItem("Name"))
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, plots: MultiPlotWidget) -> None:
+        super().__init__()
+        self._plots = plots
         self._init_col_counts()
         self.setColumnCount(self.COL_COUNT)
         self._init_table()
@@ -277,7 +279,7 @@ class StatsSignalsTable(HasRegionSignalsTable, HasDataSignalsTable):
 
     def _render_value(self, data_name: str, value: float) -> str:
         """Float-to-string conversion for a value. Optionally override this to provide smarter precision."""
-        return f"{value:.3f}"
+        return self._plots.render_value(data_name, value)
 
     def _update_stats(self) -> None:
         for row, name in enumerate(self._data_items.keys()):

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -1,0 +1,225 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from typing import List, Tuple, Optional, Literal, Union, cast
+
+import numpy as np
+import pyqtgraph as pg
+from PySide6 import QtGui
+from PySide6.QtCore import QSize
+from PySide6.QtGui import QColor, QDragMoveEvent, QDragLeaveEvent, QDropEvent
+from PySide6.QtWidgets import QMessageBox
+from numpy import typing as npt
+from pydantic import BaseModel
+
+from .multi_plot_widget import DragTargetOverlay
+from .signals_table import HasRegionSignalsTable, DraggableSignalsTable
+from .transforms_signal_table import TransformsSignalsTable
+
+
+class XyWindowModel(BaseModel):
+    xy_data_items: List[Tuple[str, str]] = []  # list of (x, y) data items
+    x_range: Optional[Union[Tuple[float, float], Literal["auto"]]] = None
+    y_range: Optional[Union[Tuple[float, float], Literal["auto"]]] = None
+
+
+class BaseXyPlot:
+    """Abstract interface for a XY plot widget"""
+
+    def __init__(self, table_parent: "XyTable"):
+        super().__init__()
+        self._parent = table_parent
+
+    def add_xy(self, x_name: str, y_name: str) -> None:
+        """Adds a XY plot to the widget"""
+        ...
+
+    def set_range(self, region: Tuple[float, float]) -> None:
+        """Sets the region to visualize the XY traces over"""
+        ...
+
+    def _write_model(self, model: BaseModel) -> None:
+        """Writes widget state to a BaseModel. Should assert it is the right type."""
+        ...
+
+    def _load_model(self, model: BaseModel) -> None:
+        """Loads widget state from a BaseModel. Should assert it is the right type."""
+        ...
+
+
+class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
+    FADE_SEGMENTS = 16
+
+    def __init__(self, table_parent: "XyTable"):
+        super().__init__(table_parent=table_parent)
+        self._xys: List[Tuple[str, str]] = []
+        self._region = (-float("inf"), float("inf"))
+
+        self._drag_overlays: List[DragTargetOverlay] = []
+        self.setAcceptDrops(True)
+
+    def _write_model(self, model: BaseModel) -> None:
+        assert isinstance(model, XyWindowModel)
+        model.xy_data_items = self._xys
+        viewbox = cast(pg.PlotItem, self.getPlotItem()).getViewBox()
+        if viewbox.autoRangeEnabled()[0]:
+            model.x_range = "auto"
+        else:
+            model.x_range = tuple(viewbox.viewRange()[0])
+        if viewbox.autoRangeEnabled()[1]:
+            model.y_range = "auto"
+        else:
+            model.y_range = tuple(viewbox.viewRange()[1])
+
+    def _load_model(self, model: BaseModel) -> None:
+        assert isinstance(model, XyWindowModel)
+        for xy_data_item in model.xy_data_items:
+            self.add_xy(*xy_data_item)
+        viewbox = cast(pg.PlotItem, self.getPlotItem()).getViewBox()
+        if model.x_range is not None and model.x_range != "auto":
+            viewbox.setXRange(model.x_range[0], model.x_range[1], 0)
+        if model.y_range is not None and model.y_range != "auto":
+            viewbox.setYRange(model.y_range[0], model.y_range[1], 0)
+        if model.x_range == "auto" or model.y_range == "auto":
+            viewbox.enableAutoRange(x=model.x_range == "auto" or None, y=model.y_range == "auto" or None)
+
+    def add_xy(self, x_name: str, y_name: str) -> None:
+        if (x_name, y_name) not in self._xys:
+            self._xys.append((x_name, y_name))
+            self._update()
+
+    def set_range(self, region: Tuple[float, float]) -> None:
+        self._region = region
+        self._update()
+
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:
+        self._parent._on_closed_xy(self)
+
+    @staticmethod
+    def _get_correlated_indices(
+        x_ts: npt.NDArray[np.float64], y_ts: npt.NDArray[np.float64], start: float, end: float
+    ) -> Optional[Tuple[Tuple[int, int], Tuple[int, int]]]:
+        """Find the indices containing start and end for x_ts and y_ts, if they are correlated
+        (evaluate to approximate the same values, and of the same size)"""
+        xt_lo, xt_hi = HasRegionSignalsTable._indices_of_region(x_ts, (start, end))
+        yt_lo, yt_hi = HasRegionSignalsTable._indices_of_region(y_ts, (start, end))
+        if xt_lo is None or xt_hi is None or yt_lo is None or yt_hi is None or xt_hi - xt_lo < 2:
+            return None
+
+        # correct for floating point imprecision in indices
+        if (xt_hi - xt_lo) == (yt_hi - yt_lo) + 1:  # delete an extra x-point
+            if abs(y_ts[yt_lo] - x_ts[xt_lo]) > abs(y_ts[yt_hi - 1] - x_ts[xt_hi - 1]):  # larger delta on low point
+                xt_lo = xt_lo + 1
+            else:
+                xt_hi = xt_hi - 1
+        elif (xt_hi - xt_lo) + 1 == (yt_hi - yt_lo):  # delete an extra y-point
+            if abs(y_ts[yt_lo] - x_ts[xt_lo]) > abs(y_ts[yt_hi - 1] - x_ts[xt_hi - 1]):  # larger delta on low point
+                yt_lo = yt_lo + 1
+            else:
+                yt_hi = yt_hi - 1
+        if (xt_hi - xt_lo) != (yt_hi - yt_lo):
+            return None
+        x_indices = x_ts[xt_lo:xt_hi]
+        y_indices = y_ts[yt_lo:yt_hi]
+        if max(abs(y_indices - x_indices)) > (y_indices[1] - y_indices[0]) / 1000:
+            return None
+        return (xt_lo, xt_hi), (yt_lo, yt_hi)
+
+    def _update(self) -> None:
+        for data_item in self.listDataItems():  # clear existing
+            self.removeItem(data_item)
+
+        data = self._parent._data
+        if isinstance(self._parent, TransformsSignalsTable):  # TODO deduplicate with PlotsTableWidget
+            transformed_data = {}
+            for data_name in data.keys():
+                transformed = self._parent.apply_transform(data_name, data)
+                if isinstance(transformed, Exception):
+                    continue
+                transformed_data[data_name] = data[data_name][0], transformed
+            data = transformed_data
+
+        for x_name, y_name in self._xys:
+            x_ts, x_ys = data.get(x_name, (None, None))
+            y_ts, y_ys = data.get(y_name, (None, None))
+            if x_ts is None or x_ys is None or y_ts is None or y_ys is None:
+                continue
+
+            # truncate to smaller series, if needed
+            region_lo = max(self._region[0], x_ts[0], y_ts[0])
+            region_hi = min(self._region[1], x_ts[-1], y_ts[-1])
+            indices = self._get_correlated_indices(x_ts, y_ts, region_lo, region_hi)
+            if indices is None:
+                print(f"X/Y indices of {x_name}, {y_name} empty or do not match")
+                continue
+            (xt_lo, xt_hi), (yt_lo, yt_hi) = indices
+
+            # PyQtGraph doesn't support native fade colors, so approximate with multiple segments
+            y_color = self._parent._data_items.get(y_name, QColor("white"))
+            fade_segments = min(
+                self.FADE_SEGMENTS, xt_hi - xt_lo
+            )  # keep track of the x time indices, apply offset for y time indices
+            last_segment_end = xt_lo
+            for i in range(fade_segments):
+                this_end = int(i / (fade_segments - 1) * (xt_hi - xt_lo)) + xt_lo
+                curve = pg.PlotCurveItem(
+                    x=x_ys[last_segment_end:this_end],
+                    y=y_ys[last_segment_end + yt_lo - xt_lo : this_end + yt_lo - xt_lo],
+                )
+                # make sure segments are continuous since this_end is exclusive,
+                # but only as far as the beginning of this segment
+                last_segment_end = max(last_segment_end, this_end - 1)
+
+                segment_color = QColor(y_color)
+                segment_color.setAlpha(int(i / (fade_segments - 1) * 255))
+                curve.setPen(color=segment_color, width=1)
+                self.addItem(curve)
+
+    def dragEnterEvent(self, event: QDragMoveEvent) -> None:
+        if not event.mimeData().data(DraggableSignalsTable.DRAG_MIME_TYPE):  # check for right type
+            return
+        overlay = DragTargetOverlay(self)
+        overlay.resize(QSize(self.width(), self.height()))
+        overlay.setVisible(True)
+        self._drag_overlays.append(overlay)
+        event.accept()
+
+    def _clear_drag_overlays(self) -> None:
+        for drag_overlay in self._drag_overlays:
+            drag_overlay.deleteLater()
+        self._drag_overlays = []
+
+    def dragMoveEvent(self, event: QDragMoveEvent) -> None:
+        event.accept()
+
+    def dragLeaveEvent(self, event: QDragLeaveEvent) -> None:
+        self._clear_drag_overlays()
+
+    def dropEvent(self, event: QDropEvent) -> None:
+        self._clear_drag_overlays()
+
+        data = event.mimeData().data(DraggableSignalsTable.DRAG_MIME_TYPE)
+        if not data:
+            return
+        drag_data_names = bytes(data.data()).decode("utf-8").split("\0")
+        if len(drag_data_names) != 2:
+            QMessageBox.critical(
+                self,
+                "Error",
+                f"Select two items for X-Y plotting, got {drag_data_names}",
+                QMessageBox.StandardButton.Ok,
+            )
+            return
+        self.add_xy(drag_data_names[0], drag_data_names[1])
+        event.accept()

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -59,6 +59,8 @@ class BaseXyPlot:
 class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
     FADE_SEGMENTS = 16
 
+    sigXysChanged = Signal()
+
     def __init__(self, plots: MultiPlotWidget):
         super().__init__(plots)
         self._xys: List[Tuple[str, str]] = []
@@ -99,6 +101,7 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
         if (x_name, y_name) not in self._xys:
             self._xys.append((x_name, y_name))
             self._update()
+        self.sigXysChanged.emit()
 
     @staticmethod
     def _get_correlated_indices(

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -66,6 +66,7 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
         self._drag_overlays: List[DragTargetOverlay] = []
         self.setAcceptDrops(True)
 
+        plots.sigDataUpdated.connect(self._update)
         if isinstance(self._plots, LinkedMultiPlotWidget):
             plots.sigCursorRangeChanged.connect(self._update)
 

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -43,10 +43,6 @@ class BaseXyPlot:
         """Adds a XY plot to the widget"""
         ...
 
-    def set_range(self, region: Tuple[float, float]) -> None:
-        """Sets the region to visualize the XY traces over"""
-        ...
-
     def _write_model(self, model: BaseModel) -> None:
         """Writes widget state to a BaseModel. Should assert it is the right type."""
         ...

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -16,7 +16,7 @@ from typing import List, Tuple, Optional, Literal, Union, cast
 
 import numpy as np
 import pyqtgraph as pg
-from PySide6.QtCore import QSize
+from PySide6.QtCore import QSize, QObject, Signal
 from PySide6.QtGui import QColor, QDragMoveEvent, QDragLeaveEvent, QDropEvent
 from PySide6.QtWidgets import QMessageBox
 from numpy import typing as npt

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 
 from .multi_plot_widget import MultiPlotWidget
 from .signals_table import SignalsTable
-from .xy_plot import BaseXyPlot, XyPlotWidget
+from .xy_plot import BaseXyPlot, XyPlotWidget, XyDragDroppable
 
 
 class XyPlotTable(QTableWidget):
@@ -59,9 +59,14 @@ class XyPlotTable(QTableWidget):
 
 
 class XyPlotSplitter(BaseXyPlot, QSplitter):
+    """XY plot splitter with a table that otherwise passes the BaseXyPlot interface items to its plot."""
+
     closed = Signal()
 
-    _XY_PLOT_TYPE: Type[XyPlotWidget] = XyPlotWidget
+    class FullXyPlotWidget(XyDragDroppable, XyPlotWidget):  # only for mixin composition
+        pass
+
+    _XY_PLOT_TYPE: Type[XyPlotWidget] = FullXyPlotWidget
     _XY_PLOT_TABLE_TYPE: Type[XyPlotTable] = XyPlotTable
 
     def _make_xy_plots(self) -> XyPlotWidget:

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -48,14 +48,11 @@ class XyPlotSplitter(BaseXyPlot, QSplitter):
     def add_xy(self, x_name: str, y_name: str) -> None:
         self._xy_plots.add_xy(x_name, y_name)
 
-    def set_range(self, region: Tuple[float, float]) -> None:
-        self._xy_plots.set_range(region)
-
     def _write_model(self, model: BaseModel) -> None:
         self._xy_plots._write_model(model)
 
     def _load_model(self, model: BaseModel) -> None:
         self._xy_plots._load_model(model)
 
-    def closeEvent(self, event: QtGui.QCloseEvent):
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:
         self.closed.emit()

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -65,7 +65,7 @@ class XyPlotSplitter(BaseXyPlot, QSplitter):
     _XY_PLOT_TABLE_TYPE: Type[XyPlotTable] = XyPlotTable
 
     def _make_xy_plots(self) -> XyPlotWidget:
-        """Creates the XyPlotTable widget. self._plots is initialized by this time.
+        """Creates the XyPlot widget. self._plots is initialized by this time.
         Optionally override to create a different XyPlotWidget object"""
         return self._XY_PLOT_TYPE(self._plots)
 

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -15,7 +15,8 @@
 from typing import Any, List, Tuple, Mapping, Optional
 
 import numpy as np
-from PySide6.QtCore import Qt
+from PySide6 import QtGui
+from PySide6.QtCore import Qt, Signal, QObject
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QMessageBox, QWidget, QSplitter, QTableWidget
 from numpy import typing as npt
@@ -34,6 +35,8 @@ class XyPlotTable(QTableWidget):
 
 
 class XyPlotSplitter(BaseXyPlot, QSplitter):
+    closed = Signal()
+
     def __init__(self, plots: MultiPlotWidget):
         super().__init__(plots)
         self.setOrientation(Qt.Orientation.Vertical)
@@ -53,3 +56,6 @@ class XyPlotSplitter(BaseXyPlot, QSplitter):
 
     def _load_model(self, model: BaseModel) -> None:
         self._xy_plots._load_model(model)
+
+    def closeEvent(self, event: QtGui.QCloseEvent):
+        self.closed.emit()

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -21,28 +21,35 @@ from PySide6.QtWidgets import QMenu, QMessageBox, QWidget, QSplitter, QTableWidg
 from numpy import typing as npt
 from pydantic import BaseModel
 
+from .multi_plot_widget import MultiPlotWidget
 from .save_restore_model import HasSaveLoadConfig, BaseTopModel
 from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable, DraggableSignalsTable
 from .xy_plot import BaseXyPlot, XyPlotWidget, XyWindowModel
 
 
+class XyPlotTable(QTableWidget):
+    def __init__(self, plot_widget: XyPlotWidget):
+        super().__init__()
+        self._plot_widget = plot_widget
+
+
 class XyPlotSplitter(BaseXyPlot, QSplitter):
-    def __init__(self, table_parent: "XyTable"):
-        super().__init__(table_parent=table_parent)
+    def __init__(self, plots: MultiPlotWidget):
+        super().__init__(plots)
         self.setOrientation(Qt.Orientation.Vertical)
-        self._plots = XyPlotWidget(table_parent=table_parent)
-        self.addWidget(self._plots)
-        self._table = QTableWidget()
+        self._xy_plots = XyPlotWidget(plots)
+        self.addWidget(self._xy_plots)
+        self._table = XyPlotTable(self._xy_plots)
         self.addWidget(self._table)
 
     def add_xy(self, x_name: str, y_name: str) -> None:
-        self._plots.add_xy(x_name, y_name)
+        self._xy_plots.add_xy(x_name, y_name)
 
     def set_range(self, region: Tuple[float, float]) -> None:
-        self._plots.set_range(region)
+        self._xy_plots.set_range(region)
 
     def _write_model(self, model: BaseModel) -> None:
-        self._plots._write_model(model)
+        self._xy_plots._write_model(model)
 
     def _load_model(self, model: BaseModel) -> None:
-        self._plots._load_model(model)
+        self._xy_plots._load_model(model)

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -1,0 +1,48 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from typing import Any, List, Tuple, Mapping, Optional
+
+import numpy as np
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QMenu, QMessageBox, QWidget, QSplitter, QTableWidget
+from numpy import typing as npt
+from pydantic import BaseModel
+
+from .save_restore_model import HasSaveLoadConfig, BaseTopModel
+from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable, DraggableSignalsTable
+from .xy_plot import BaseXyPlot, XyPlotWidget, XyWindowModel
+
+
+class XyPlotSplitter(BaseXyPlot, QSplitter):
+    def __init__(self, table_parent: "XyTable"):
+        super().__init__(table_parent=table_parent)
+        self.setOrientation(Qt.Orientation.Vertical)
+        self._plots = XyPlotWidget(table_parent=table_parent)
+        self.addWidget(self._plots)
+        self._table = QTableWidget()
+        self.addWidget(self._table)
+
+    def add_xy(self, x_name: str, y_name: str) -> None:
+        self._plots.add_xy(x_name, y_name)
+
+    def set_range(self, region: Tuple[float, float]) -> None:
+        self._plots.set_range(region)
+
+    def _write_model(self, model: BaseModel) -> None:
+        self._plots._write_model(model)
+
+    def _load_model(self, model: BaseModel) -> None:
+        self._plots._load_model(model)

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -11,6 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+from typing import Type
 
 from PySide6 import QtGui
 from PySide6.QtCore import Qt, Signal
@@ -60,12 +61,25 @@ class XyPlotTable(QTableWidget):
 class XyPlotSplitter(BaseXyPlot, QSplitter):
     closed = Signal()
 
+    _XY_PLOT_TYPE: Type[XyPlotWidget] = XyPlotWidget
+    _XY_PLOT_TABLE_TYPE: Type[XyPlotTable] = XyPlotTable
+
+    def _make_xy_plots(self) -> XyPlotWidget:
+        """Creates the XyPlotTable widget. self._plots is initialized by this time.
+        Optionally override to create a different XyPlotWidget object"""
+        return self._XY_PLOT_TYPE(self._plots)
+
+    def _make_xy_plot_table(self) -> XyPlotTable:
+        """Creates the XyPlotTable widget. self._plots and self._xy_plots are initialized by this time.
+        Optionally override to create a different XyPlotTable object"""
+        return self._XY_PLOT_TABLE_TYPE(self._plots, self._xy_plots)
+
     def __init__(self, plots: MultiPlotWidget):
         super().__init__(plots)
         self.setOrientation(Qt.Orientation.Vertical)
-        self._xy_plots = XyPlotWidget(plots)
+        self._xy_plots = self._make_xy_plots()
         self.addWidget(self._xy_plots)
-        self._table = XyPlotTable(plots, self._xy_plots)
+        self._table = self._make_xy_plot_table()
         self.addWidget(self._table)
 
     def add_xy(self, x_name: str, y_name: str) -> None:

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -39,7 +39,7 @@ class XyPlotTable(QTableWidget):
         self.setHorizontalHeaderItem(self.COL_X_NAME, QTableWidgetItem("X"))
         self.setHorizontalHeaderItem(self.COL_Y_NAME, QTableWidgetItem("Y"))
 
-    def _update(self):
+    def _update(self) -> None:
         self.setRowCount(0)  # clear table
         self.setRowCount(len(self._xy_plots._xys))
         for row, (x_name, y_name) in enumerate(self._xy_plots._xys):

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -23,8 +23,8 @@ from PySide6.QtWidgets import QMenu, QMessageBox, QWidget
 from numpy import typing as npt
 from pydantic import BaseModel
 
-from .save_restore_model import HasSaveLoadConfig, BaseTopModel
 from .multi_plot_widget import DragTargetOverlay
+from .save_restore_model import HasSaveLoadConfig, BaseTopModel
 from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable, DraggableSignalsTable
 from .transforms_signal_table import TransformsSignalsTable
 
@@ -38,8 +38,9 @@ class XyWindowModel(BaseModel):
 class BaseXyPlot:
     """Abstract interface for a XY plot widget"""
 
-    def __init__(self, parent: "XyTable"):
+    def __init__(self, table_parent: "XyTable"):
         super().__init__()
+        self._parent = table_parent
 
     def add_xy(self, x_name: str, y_name: str) -> None:
         """Adds a XY plot to the widget"""
@@ -58,12 +59,11 @@ class BaseXyPlot:
         ...
 
 
-class XyPlotWidget(pg.PlotWidget, BaseXyPlot):  # type: ignore[misc]
+class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
     FADE_SEGMENTS = 16
 
-    def __init__(self, parent: "XyTable"):
-        super().__init__(parent)
-        self._parent = parent
+    def __init__(self, table_parent: "XyTable"):
+        super().__init__(table_parent=table_parent)
         self._xys: List[Tuple[str, str]] = []
         self._region = (-float("inf"), float("inf"))
 
@@ -296,7 +296,7 @@ class XyTable(
 
     def create_xy(self) -> BaseXyPlot:
         """Creates and opens an empty XY plot widget."""
-        xy_plot = XyPlotWidget(self)
+        xy_plot = XyPlotWidget(table_parent=self)
         xy_plot.show()
         xy_plot.set_range(self._range)
         self._xy_plots.append(xy_plot)  # need an active reference to prevent GC'ing

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -40,7 +40,7 @@ class XyTable(
         super().__init__(*args, **kwargs)
         self._xy_action = QAction("Create X-Y Plot", self)
         self._xy_action.triggered.connect(self._on_create_xy)
-        self._xy_plots: List[BaseXyPlot] = []  # TODO store as weakrefs, so closes properly registered
+        self._xy_plots: List[BaseXyPlot] = []
 
     def _write_model(self, model: BaseTopModel) -> None:
         super()._write_model(model)
@@ -65,19 +65,6 @@ class XyTable(
     def _populate_context_menu(self, menu: QMenu) -> None:
         super()._populate_context_menu(menu)
         menu.addAction(self._xy_action)
-
-    def set_data(
-        self,
-        data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
-    ) -> None:
-        # TODO refactor to listen on MPW signal - for each individual XYPlotWidget
-        super().set_data(data)
-        self._update_xys()
-
-    def _update_xys(self) -> None:
-        # TODO eliminate this, each widget individually listens for data and region events
-        for xy_plot in self._xy_plots:
-            xy_plot.set_range(self._range)
 
     def _on_create_xy(self) -> Optional[BaseXyPlot]:
         """Creates an XY plot with the selected signal(s) and returns the new plot."""

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -40,7 +40,7 @@ class XyTable(
         super().__init__(*args, **kwargs)
         self._xy_action = QAction("Create X-Y Plot", self)
         self._xy_action.triggered.connect(self._on_create_xy)
-        self._xy_plots: List[BaseXyPlot] = []
+        self._xy_plots: List[BaseXyPlot] = []  # TODO store as weakrefs, so closes properly registered
 
     def _write_model(self, model: BaseTopModel) -> None:
         super()._write_model(model)
@@ -67,6 +67,7 @@ class XyTable(
         menu.addAction(self._xy_action)
 
     def set_range(self, range: Tuple[float, float]) -> None:
+        # TODO refactor to listen on MPW signal - for each individual XYPlotWidget
         super().set_range(range)
         self._update_xys()
 
@@ -74,10 +75,12 @@ class XyTable(
         self,
         data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
     ) -> None:
+        # TODO refactor to listen on MPW signal - for each individual XYPlotWidget
         super().set_data(data)
         self._update_xys()
 
     def _update_xys(self) -> None:
+        # TODO eliminate this, each widget individually listens for data and region events
         for xy_plot in self._xy_plots:
             xy_plot.set_range(self._range)
 
@@ -95,7 +98,7 @@ class XyTable(
 
     def create_xy(self) -> BaseXyPlot:
         """Creates and opens an empty XY plot widget."""
-        xy_plot = XyPlotSplitter(table_parent=self)
+        xy_plot = XyPlotSplitter(self._plots)
         xy_plot.show()
         xy_plot.set_range(self._range)
         self._xy_plots.append(xy_plot)  # need an active reference to prevent GC'ing

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -12,218 +12,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from typing import Any, List, Tuple, Mapping, Optional, Literal, Union, cast
+from typing import Any, List, Tuple, Mapping, Optional
 
 import numpy as np
-import pyqtgraph as pg
-from PySide6 import QtGui
-from PySide6.QtCore import QSize
-from PySide6.QtGui import QAction, QColor, QDragMoveEvent, QDragLeaveEvent, QDropEvent
+from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QMessageBox, QWidget
 from numpy import typing as npt
-from pydantic import BaseModel
 
-from .multi_plot_widget import DragTargetOverlay
 from .save_restore_model import HasSaveLoadConfig, BaseTopModel
 from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable, DraggableSignalsTable
-from .transforms_signal_table import TransformsSignalsTable
-
-
-class XyWindowModel(BaseModel):
-    xy_data_items: List[Tuple[str, str]] = []  # list of (x, y) data items
-    x_range: Optional[Union[Tuple[float, float], Literal["auto"]]] = None
-    y_range: Optional[Union[Tuple[float, float], Literal["auto"]]] = None
-
-
-class BaseXyPlot:
-    """Abstract interface for a XY plot widget"""
-
-    def __init__(self, table_parent: "XyTable"):
-        super().__init__()
-        self._parent = table_parent
-
-    def add_xy(self, x_name: str, y_name: str) -> None:
-        """Adds a XY plot to the widget"""
-        ...
-
-    def set_range(self, region: Tuple[float, float]) -> None:
-        """Sets the region to visualize the XY traces over"""
-        ...
-
-    def _write_model(self, model: BaseModel) -> None:
-        """Writes widget state to a BaseModel. Should assert it is the right type."""
-        ...
-
-    def _load_model(self, model: BaseModel) -> None:
-        """Loads widget state from a BaseModel. Should assert it is the right type."""
-        ...
-
-
-class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
-    FADE_SEGMENTS = 16
-
-    def __init__(self, table_parent: "XyTable"):
-        super().__init__(table_parent=table_parent)
-        self._xys: List[Tuple[str, str]] = []
-        self._region = (-float("inf"), float("inf"))
-
-        self._drag_overlays: List[DragTargetOverlay] = []
-        self.setAcceptDrops(True)
-
-    def _write_model(self, model: BaseModel) -> None:
-        assert isinstance(model, XyWindowModel)
-        model.xy_data_items = self._xys
-        viewbox = cast(pg.PlotItem, self.getPlotItem()).getViewBox()
-        if viewbox.autoRangeEnabled()[0]:
-            model.x_range = "auto"
-        else:
-            model.x_range = tuple(viewbox.viewRange()[0])
-        if viewbox.autoRangeEnabled()[1]:
-            model.y_range = "auto"
-        else:
-            model.y_range = tuple(viewbox.viewRange()[1])
-
-    def _load_model(self, model: BaseModel) -> None:
-        assert isinstance(model, XyWindowModel)
-        for xy_data_item in model.xy_data_items:
-            self.add_xy(*xy_data_item)
-        viewbox = cast(pg.PlotItem, self.getPlotItem()).getViewBox()
-        if model.x_range is not None and model.x_range != "auto":
-            viewbox.setXRange(model.x_range[0], model.x_range[1], 0)
-        if model.y_range is not None and model.y_range != "auto":
-            viewbox.setYRange(model.y_range[0], model.y_range[1], 0)
-        if model.x_range == "auto" or model.y_range == "auto":
-            viewbox.enableAutoRange(x=model.x_range == "auto" or None, y=model.y_range == "auto" or None)
-
-    def add_xy(self, x_name: str, y_name: str) -> None:
-        if (x_name, y_name) not in self._xys:
-            self._xys.append((x_name, y_name))
-            self._update()
-
-    def set_range(self, region: Tuple[float, float]) -> None:
-        self._region = region
-        self._update()
-
-    def closeEvent(self, event: QtGui.QCloseEvent) -> None:
-        self._parent._on_closed_xy(self)
-
-    @staticmethod
-    def _get_correlated_indices(
-        x_ts: npt.NDArray[np.float64], y_ts: npt.NDArray[np.float64], start: float, end: float
-    ) -> Optional[Tuple[Tuple[int, int], Tuple[int, int]]]:
-        """Find the indices containing start and end for x_ts and y_ts, if they are correlated
-        (evaluate to approximate the same values, and of the same size)"""
-        xt_lo, xt_hi = HasRegionSignalsTable._indices_of_region(x_ts, (start, end))
-        yt_lo, yt_hi = HasRegionSignalsTable._indices_of_region(y_ts, (start, end))
-        if xt_lo is None or xt_hi is None or yt_lo is None or yt_hi is None or xt_hi - xt_lo < 2:
-            return None
-
-        # correct for floating point imprecision in indices
-        if (xt_hi - xt_lo) == (yt_hi - yt_lo) + 1:  # delete an extra x-point
-            if abs(y_ts[yt_lo] - x_ts[xt_lo]) > abs(y_ts[yt_hi - 1] - x_ts[xt_hi - 1]):  # larger delta on low point
-                xt_lo = xt_lo + 1
-            else:
-                xt_hi = xt_hi - 1
-        elif (xt_hi - xt_lo) + 1 == (yt_hi - yt_lo):  # delete an extra y-point
-            if abs(y_ts[yt_lo] - x_ts[xt_lo]) > abs(y_ts[yt_hi - 1] - x_ts[xt_hi - 1]):  # larger delta on low point
-                yt_lo = yt_lo + 1
-            else:
-                yt_hi = yt_hi - 1
-        if (xt_hi - xt_lo) != (yt_hi - yt_lo):
-            return None
-        x_indices = x_ts[xt_lo:xt_hi]
-        y_indices = y_ts[yt_lo:yt_hi]
-        if max(abs(y_indices - x_indices)) > (y_indices[1] - y_indices[0]) / 1000:
-            return None
-        return (xt_lo, xt_hi), (yt_lo, yt_hi)
-
-    def _update(self) -> None:
-        for data_item in self.listDataItems():  # clear existing
-            self.removeItem(data_item)
-
-        data = self._parent._data
-        if isinstance(self._parent, TransformsSignalsTable):  # TODO deduplicate with PlotsTableWidget
-            transformed_data = {}
-            for data_name in data.keys():
-                transformed = self._parent.apply_transform(data_name, data)
-                if isinstance(transformed, Exception):
-                    continue
-                transformed_data[data_name] = data[data_name][0], transformed
-            data = transformed_data
-
-        for x_name, y_name in self._xys:
-            x_ts, x_ys = data.get(x_name, (None, None))
-            y_ts, y_ys = data.get(y_name, (None, None))
-            if x_ts is None or x_ys is None or y_ts is None or y_ys is None:
-                continue
-
-            # truncate to smaller series, if needed
-            region_lo = max(self._region[0], x_ts[0], y_ts[0])
-            region_hi = min(self._region[1], x_ts[-1], y_ts[-1])
-            indices = self._get_correlated_indices(x_ts, y_ts, region_lo, region_hi)
-            if indices is None:
-                print(f"X/Y indices of {x_name}, {y_name} empty or do not match")
-                continue
-            (xt_lo, xt_hi), (yt_lo, yt_hi) = indices
-
-            # PyQtGraph doesn't support native fade colors, so approximate with multiple segments
-            y_color = self._parent._data_items.get(y_name, QColor("white"))
-            fade_segments = min(
-                self.FADE_SEGMENTS, xt_hi - xt_lo
-            )  # keep track of the x time indices, apply offset for y time indices
-            last_segment_end = xt_lo
-            for i in range(fade_segments):
-                this_end = int(i / (fade_segments - 1) * (xt_hi - xt_lo)) + xt_lo
-                curve = pg.PlotCurveItem(
-                    x=x_ys[last_segment_end:this_end],
-                    y=y_ys[last_segment_end + yt_lo - xt_lo : this_end + yt_lo - xt_lo],
-                )
-                # make sure segments are continuous since this_end is exclusive,
-                # but only as far as the beginning of this segment
-                last_segment_end = max(last_segment_end, this_end - 1)
-
-                segment_color = QColor(y_color)
-                segment_color.setAlpha(int(i / (fade_segments - 1) * 255))
-                curve.setPen(color=segment_color, width=1)
-                self.addItem(curve)
-
-    def dragEnterEvent(self, event: QDragMoveEvent) -> None:
-        if not event.mimeData().data(DraggableSignalsTable.DRAG_MIME_TYPE):  # check for right type
-            return
-        overlay = DragTargetOverlay(self)
-        overlay.resize(QSize(self.width(), self.height()))
-        overlay.setVisible(True)
-        self._drag_overlays.append(overlay)
-        event.accept()
-
-    def _clear_drag_overlays(self) -> None:
-        for drag_overlay in self._drag_overlays:
-            drag_overlay.deleteLater()
-        self._drag_overlays = []
-
-    def dragMoveEvent(self, event: QDragMoveEvent) -> None:
-        event.accept()
-
-    def dragLeaveEvent(self, event: QDragLeaveEvent) -> None:
-        self._clear_drag_overlays()
-
-    def dropEvent(self, event: QDropEvent) -> None:
-        self._clear_drag_overlays()
-
-        data = event.mimeData().data(DraggableSignalsTable.DRAG_MIME_TYPE)
-        if not data:
-            return
-        drag_data_names = bytes(data.data()).decode("utf-8").split("\0")
-        if len(drag_data_names) != 2:
-            QMessageBox.critical(
-                self,
-                "Error",
-                f"Select two items for X-Y plotting, got {drag_data_names}",
-                QMessageBox.StandardButton.Ok,
-            )
-            return
-        self.add_xy(drag_data_names[0], drag_data_names[1])
-        event.accept()
+from .xy_plot import BaseXyPlot, XyPlotWidget, XyWindowModel
+from .xy_plot_splitter import XyPlotSplitter
 
 
 class XyTableStateModel(BaseTopModel):
@@ -296,11 +95,11 @@ class XyTable(
 
     def create_xy(self) -> BaseXyPlot:
         """Creates and opens an empty XY plot widget."""
-        xy_plot = XyPlotWidget(table_parent=self)
+        xy_plot = XyPlotSplitter(table_parent=self)
         xy_plot.show()
         xy_plot.set_range(self._range)
         self._xy_plots.append(xy_plot)  # need an active reference to prevent GC'ing
         return xy_plot
 
-    def _on_closed_xy(self, closed: XyPlotWidget) -> None:
+    def _on_closed_xy(self, closed: BaseXyPlot) -> None:
         self._xy_plots = [plot for plot in self._xy_plots if plot is not closed]

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -11,7 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-
+from functools import partial
 from typing import Any, List, Tuple, Mapping, Optional
 
 import numpy as np
@@ -66,11 +66,6 @@ class XyTable(
         super()._populate_context_menu(menu)
         menu.addAction(self._xy_action)
 
-    def set_range(self, range: Tuple[float, float]) -> None:
-        # TODO refactor to listen on MPW signal - for each individual XYPlotWidget
-        super().set_range(range)
-        self._update_xys()
-
     def set_data(
         self,
         data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
@@ -102,6 +97,7 @@ class XyTable(
         xy_plot.show()
         xy_plot.set_range(self._range)
         self._xy_plots.append(xy_plot)  # need an active reference to prevent GC'ing
+        xy_plot.closed.connect(partial(self._on_closed_xy, xy_plot))
         return xy_plot
 
     def _on_closed_xy(self, closed: BaseXyPlot) -> None:

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -12,16 +12,14 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 from functools import partial
-from typing import Any, List, Tuple, Mapping, Optional
+from typing import Any, List, Optional
 
-import numpy as np
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QMessageBox, QWidget
-from numpy import typing as npt
 
 from .save_restore_model import HasSaveLoadConfig, BaseTopModel
 from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable, DraggableSignalsTable
-from .xy_plot import BaseXyPlot, XyPlotWidget, XyWindowModel
+from .xy_plot import BaseXyPlot, XyWindowModel
 from .xy_plot_splitter import XyPlotSplitter
 
 
@@ -82,7 +80,6 @@ class XyTable(
         """Creates and opens an empty XY plot widget."""
         xy_plot = XyPlotSplitter(self._plots)
         xy_plot.show()
-        xy_plot.set_range(self._range)
         self._xy_plots.append(xy_plot)  # need an active reference to prevent GC'ing
         xy_plot.closed.connect(partial(self._on_closed_xy, xy_plot))
         return xy_plot

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -15,20 +15,18 @@
 from io import StringIO
 from typing import cast
 
-import pytest
 import pyqtgraph as pg
+import pytest
 from PySide6.QtGui import QColor
 from pytestqt.qtbot import QtBot
 
-from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
 from pyqtgraph_scope_plots.multi_plot_widget import (
     MultiPlotWidget,
     MultiPlotStateModel,
-    LinkedMultiPlotStateModel,
     PlotWidgetModel,
 )
+from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
 from .test_util import assert_cast
-from pyqtgraph_scope_plots.util import not_none
 
 
 @pytest.fixture()
@@ -97,6 +95,13 @@ def test_empty_default_plots(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     plot._set_data_items([])
     qtbot.waitUntil(lambda: plot._plots.count() == 1)
     assert plot._table.rowCount() == 0
+
+
+def test_data_signals(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    plot._set_data({})
+    qtbot.waitSignals([plot._plots.sigDataUpdated])
+    plot._set_data_items([])
+    qtbot.waitSignals([plot._plots.sigDataItemsUpdated, plot._plots.sigDataUpdated])
 
 
 def test_plot_merge(qtbot: QtBot, plot: PlotsTableWidget) -> None:

--- a/tests/test_linked_plot.py
+++ b/tests/test_linked_plot.py
@@ -28,10 +28,12 @@ def test_linked_live_cursor(qtbot: QtBot, plot: PlotsTableWidget) -> None:
         assert plot_item(plot, i).hover_cursor is None  # verify initial state
 
     plot_item(plot, 0).set_live_cursor(0.1)
+    qtbot.waitSignal(plot._plots.sigHoverCursorChanged)
     qtbot.waitUntil(lambda: not_none(plot_item(plot, 1).hover_cursor).x() == 0.1)
     assert not_none(plot_item(plot, 2).hover_cursor).x() == 0.1
 
     plot_item(plot, 1).set_live_cursor(None)
+    qtbot.waitSignal(plot._plots.sigHoverCursorChanged)
     qtbot.waitUntil(lambda: plot_item(plot, 0).hover_cursor is None)
     assert plot_item(plot, 2).hover_cursor is None
 
@@ -42,12 +44,14 @@ def test_linked_region(qtbot: QtBot, plot: PlotsTableWidget) -> None:
         assert plot_item(plot, i).cursor_range is None
 
     plot_item(plot, 0).set_region((0.1, 1.5))
+    qtbot.waitSignal(plot._plots.sigCursorRangeChanged)
     qtbot.waitUntil(lambda: not_none(plot_item(plot, 1).cursor_range).getRegion() == (0.1, 1.5))
     assert not_none(plot_item(plot, 2).cursor_range).getRegion() == (0.1, 1.5)
     for i in range(3):
         assert plot_item(plot, i).cursor is None
 
     plot_item(plot, 1).set_region(1.0)
+    qtbot.waitSignal(plot._plots.sigCursorRangeChanged)
     qtbot.waitUntil(lambda: not_none(plot_item(plot, 0).cursor).x() == 1.0)
     assert not_none(plot_item(plot, 2).cursor).x() == 1.0
     for i in range(3):
@@ -100,6 +104,7 @@ def test_linked_pois(qtbot: QtBot, plot: PlotsTableWidget) -> None:
         assert not plot_item(plot, i).pois  # verify initial state
 
     plot_item(plot, 0).set_pois([0.1, 1.5])
+    qtbot.waitSignal(plot._plots.sigPoiChanged)
     qtbot.waitUntil(lambda: [poi.x() for poi in plot_item(plot, 1).pois] == [0.1, 1.5])
     assert [poi.x() for poi in plot_item(plot, 2).pois] == [0.1, 1.5]
 
@@ -128,6 +133,7 @@ def test_linked_drag_cursor(qtbot: QtBot, plot: PlotsTableWidget) -> None:
         assert plot_item(plot, i).drag_cursor is None  # verify initial state
 
     plot_item(plot, 0).set_drag_cursor(0.2)
+    qtbot.waitSignal(plot._plots.sigDragCursorChanged)
     qtbot.waitUntil(
         lambda: plot_item(plot, 1).drag_cursor is not None and plot_item(plot, 1).drag_cursor.pos().x() == 0.2
     )

--- a/tests/test_table_search.py
+++ b/tests/test_table_search.py
@@ -16,13 +16,14 @@ import pytest
 from PySide6.QtGui import QColor
 from pytestqt.qtbot import QtBot
 
+from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
 from pyqtgraph_scope_plots.search_signals_table import SearchSignalsTable
 
 
 @pytest.fixture()
 def search_table(qtbot: QtBot) -> SearchSignalsTable:
     """Creates a signals plot with multiple data items"""
-    table = SearchSignalsTable()
+    table = SearchSignalsTable(MultiPlotWidget())
     table.set_data_items([("aaa", QColor("yellow")), ("abC", QColor("orange")), ("abd", QColor("blue"))])
     qtbot.addWidget(table)
     table.show()

--- a/tests/test_transforms_timeshift_table.py
+++ b/tests/test_transforms_timeshift_table.py
@@ -22,6 +22,7 @@ from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QInputDialog
 from pytestqt.qtbot import QtBot
 
+from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
 from pyqtgraph_scope_plots.timeshift_signals_table import TimeshiftSignalsTable, TimeshiftDataStateModel
 from pyqtgraph_scope_plots.transforms_signal_table import TransformsSignalsTable, TransformsDataStateModel
 from pyqtgraph_scope_plots.util import not_none
@@ -31,7 +32,7 @@ from .test_util import context_menu, menu_action_by_name
 @pytest.fixture()
 def transforms_table(qtbot: QtBot) -> TransformsSignalsTable:
     """Creates a signals plot with multiple data items"""
-    table = TransformsSignalsTable()
+    table = TransformsSignalsTable(MultiPlotWidget())
     table.set_data_items([("0", QColor("yellow")), ("1", QColor("orange")), ("2", QColor("blue"))])
     qtbot.addWidget(table)
     table.show()
@@ -42,7 +43,7 @@ def transforms_table(qtbot: QtBot) -> TransformsSignalsTable:
 @pytest.fixture()
 def timeshifts_table(qtbot: QtBot) -> TimeshiftSignalsTable:
     """Creates a signals plot with multiple data items"""
-    table = TimeshiftSignalsTable()
+    table = TimeshiftSignalsTable(MultiPlotWidget())
     table.set_data_items([("0", QColor("yellow")), ("1", QColor("orange")), ("2", QColor("blue"))])
     qtbot.addWidget(table)
     table.show()

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -88,6 +88,7 @@ def test_xy_create_ui(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     plot._table.item(1, 0).setSelected(True)
     plot._table.item(0, 0).setSelected(True)
     xy_plot = cast(XyPlotSplitter, plot._table._on_create_xy())
+    qtbot.waitSignal(xy_plot._xy_plots.sigXysChanged)
     assert xy_plot is not None
     assert xy_plot._xy_plots._xys == [("1", "0")]
 
@@ -95,6 +96,7 @@ def test_xy_create_ui(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     plot._table.item(0, 0).setSelected(True)
     plot._table.item(1, 0).setSelected(True)
     xy_plot = cast(XyPlotSplitter, plot._table._on_create_xy())
+    qtbot.waitSignal(xy_plot._xy_plots.sigXysChanged)
     assert xy_plot is not None
     assert xy_plot._xy_plots._xys == [("0", "1")]
 

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -21,6 +21,7 @@ from pytestqt.qtbot import QtBot
 from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
 from pyqtgraph_scope_plots.xy_plot import XyPlotWidget, XyWindowModel
+from pyqtgraph_scope_plots.xy_plot_splitter import XyPlotSplitter
 from pyqtgraph_scope_plots.xy_plot_table import XyTableStateModel
 
 
@@ -86,25 +87,25 @@ def test_xy_create_ui(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     # test that xy creation doesn't error out and follows the user order
     plot._table.item(1, 0).setSelected(True)
     plot._table.item(0, 0).setSelected(True)
-    xy_plot = cast(XyPlotWidget, plot._table._on_create_xy())
+    xy_plot = cast(XyPlotSplitter, plot._table._on_create_xy())
     assert xy_plot is not None
-    assert xy_plot._xys == [("1", "0")]
+    assert xy_plot._xy_plots._xys == [("1", "0")]
 
     plot._table.clearSelection()
     plot._table.item(0, 0).setSelected(True)
     plot._table.item(1, 0).setSelected(True)
-    xy_plot = cast(XyPlotWidget, plot._table._on_create_xy())
+    xy_plot = cast(XyPlotSplitter, plot._table._on_create_xy())
     assert xy_plot is not None
-    assert xy_plot._xys == [("0", "1")]
+    assert xy_plot._xy_plots._xys == [("0", "1")]
 
     qtbot.wait(10)  # wait for rendering to happen
 
 
 def test_xy_offset(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    xy_plot = cast(XyPlotWidget, plot._table.create_xy())
+    xy_plot = cast(XyPlotSplitter, plot._table.create_xy())
     xy_plot.add_xy("0", "2")
     xy_plot.add_xy("2", "0")
-    assert xy_plot._xys == [("0", "2"), ("2", "0")]
+    assert xy_plot._xy_plots._xys == [("0", "2"), ("2", "0")]
 
     qtbot.wait(10)  # wait for rendering to happen to ensure it doesn't error
 
@@ -125,4 +126,4 @@ def test_xy_load(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     model.xy_windows = [XyWindowModel(xy_data_items=[("1", "0")])]
     plot._table._load_model(model)
     qtbot.waitUntil(lambda: len(plot._table._xy_plots) == 1)
-    assert cast(XyPlotWidget, plot._table._xy_plots[0])._xys == [("1", "0")]
+    assert cast(XyPlotSplitter, plot._table._xy_plots[0])._xy_plots._xys == [("1", "0")]

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -85,14 +85,14 @@ def test_xy_create_ui(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     # test that xy creation doesn't error out and follows the user order
     plot._table.item(1, 0).setSelected(True)
     plot._table.item(0, 0).setSelected(True)
-    xy_plot = plot._table._on_create_xy()
+    xy_plot = cast(XyPlotWidget, plot._table._on_create_xy())
     assert xy_plot is not None
     assert xy_plot._xys == [("1", "0")]
 
     plot._table.clearSelection()
     plot._table.item(0, 0).setSelected(True)
     plot._table.item(1, 0).setSelected(True)
-    xy_plot = plot._table._on_create_xy()
+    xy_plot = cast(XyPlotWidget, plot._table._on_create_xy())
     assert xy_plot is not None
     assert xy_plot._xys == [("0", "1")]
 
@@ -100,7 +100,7 @@ def test_xy_create_ui(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
 
 def test_xy_offset(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    xy_plot = plot._table.create_xy()
+    xy_plot = cast(XyPlotWidget, plot._table.create_xy())
     xy_plot.add_xy("0", "2")
     xy_plot.add_xy("2", "0")
     assert xy_plot._xys == [("0", "2"), ("2", "0")]
@@ -109,7 +109,7 @@ def test_xy_offset(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
 
 def test_xy_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    xy_plot = plot._table.create_xy()
+    xy_plot = cast(XyPlotWidget, plot._table.create_xy())
     xy_plot.add_xy("0", "1")
     xy_plot.add_xy("1", "0")
     qtbot.waitUntil(
@@ -124,4 +124,4 @@ def test_xy_load(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     model.xy_windows = [XyWindowModel(xy_data_items=[("1", "0")])]
     plot._table._load_model(model)
     qtbot.waitUntil(lambda: len(plot._table._xy_plots) == 1)
-    assert plot._table._xy_plots[0]._xys == [("1", "0")]
+    assert cast(XyPlotWidget, plot._table._xy_plots[0])._xys == [("1", "0")]

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -20,7 +20,7 @@ from pytestqt.qtbot import QtBot
 
 from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
-from pyqtgraph_scope_plots.xy_plot_table import XyPlotWidget, XyTableStateModel, XyWindowModel
+from pyqtgraph_scope_plots.xy_plot import XyPlotWidget, XyTableStateModel, XyWindowModel
 
 
 @pytest.fixture()

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -20,7 +20,8 @@ from pytestqt.qtbot import QtBot
 
 from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
-from pyqtgraph_scope_plots.xy_plot import XyPlotWidget, XyTableStateModel, XyWindowModel
+from pyqtgraph_scope_plots.xy_plot import XyPlotWidget, XyWindowModel
+from pyqtgraph_scope_plots.xy_plot_table import XyTableStateModel
 
 
 @pytest.fixture()

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -113,7 +113,7 @@ def test_xy_offset(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
 
 def test_xy_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    xy_plot = cast(XyPlotWidget, plot._table.create_xy())
+    xy_plot = plot._table.create_xy()
     xy_plot.add_xy("0", "1")
     xy_plot.add_xy("1", "0")
     qtbot.waitUntil(
@@ -129,3 +129,18 @@ def test_xy_load(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     plot._table._load_model(model)
     qtbot.waitUntil(lambda: len(plot._table._xy_plots) == 1)
     assert cast(XyPlotSplitter, plot._table._xy_plots[0])._xy_plots._xys == [("1", "0")]
+
+
+def test_xy_table(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    xy_plot = cast(XyPlotSplitter, plot._table.create_xy())
+    xy_plot.add_xy("0", "1")
+    qtbot.waitUntil(lambda: xy_plot._table.rowCount() == 1)
+    assert xy_plot._table.item(0, 0).text() == "0"
+    assert xy_plot._table.item(0, 1).text() == "1"
+
+    xy_plot.add_xy("1", "0")
+    qtbot.waitUntil(lambda: xy_plot._table.rowCount() == 2)
+    assert xy_plot._table.item(0, 0).text() == "0"
+    assert xy_plot._table.item(0, 1).text() == "1"
+    assert xy_plot._table.item(1, 0).text() == "1"
+    assert xy_plot._table.item(1, 1).text() == "0"


### PR DESCRIPTION
Modifies the XY plot widget to be a splitter with a table component. Architecturally, this has the table subordinate to plots, the table is only a controller into the plots and uses the signals from the plot (instead of the top-level splitter being the coordinator). A bit of a test of how this works before refactoring the main plot / signals-table to use this architecture.

Changes the behavior of the top-level window (for the CSV viewer) to close sub-XY-windows.

Changes to the multi-plot widget:
- Adds sigDataItemsUpdated, sigDataUpdated, which the XY plot listens on directly (instead of through the table's data-updated)
- Add tests for updated signal
- Changes signals to fire only after the internal state has been updated, e.g., region-updated signal after plots._region set

Changes to signals table:
- Base signals table now directly has a reference to the plots
- _render_value plumbed to the plots directly

Changes to XY plot architecture:
- Create a BaseXyPlot that can be inherited by the plot only or the splitter.
- Provides a sigXysChanged signals, which can be used in combination with plots.sigDataItemsChanged for a table to listen for updates
- Breaks out the drag-and-drop target feature into a separate mixin
- Split into three files: the base plot + widget, the SignalsTable item to open XY plots, and the XY splitter widget
- Listens directly to the plot for data / region changes