### PR TITLE
Add reference geometry for xy plots, refactor save-model infrastructure

### DIFF
--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -33,8 +33,8 @@ from .timeshift_signals_table import TimeshiftSignalsTable
 from .transforms_signal_table import TransformsSignalsTable
 from .search_signals_table import SearchSignalsTable
 from .xy_plot_table import XyTable
-from .xy_plot import XyPlotWidget, XyDragDroppable
-from .xy_plot_splitter import XyPlotTable, XyPlotSplitter
+from .xy_plot import XyPlotWidget, XyDragDroppable, XyPlotTable
+from .xy_plot_splitter import XyPlotSplitter
 
 from .time_axis import TimeAxisItem
 

--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -33,6 +33,8 @@ from .timeshift_signals_table import TimeshiftSignalsTable
 from .transforms_signal_table import TransformsSignalsTable
 from .search_signals_table import SearchSignalsTable
 from .xy_plot_table import XyTable
+from .xy_plot import XyPlotWidget, XyDragDroppable
+from .xy_plot_splitter import XyPlotTable, XyPlotSplitter
 
 from .time_axis import TimeAxisItem
 

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -432,7 +432,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
             f.write(yaml.dump(model.model_dump(), sort_keys=False))
 
     def _do_save_config(self, filename: str) -> CsvLoaderStateModel:
-        model = self._dump_model(self._table._data_items.keys())
+        model = self._dump_data_model(self._table._data_items.keys())
         assert isinstance(model, CsvLoaderStateModel)
 
         if len(self._csv_data_items) == 0:

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -37,6 +37,7 @@ from PySide6.QtWidgets import (
     QToolButton,
     QMessageBox,
 )
+from pydantic import BaseModel
 from pydantic._internal._model_construction import ModelMetaclass
 
 from ..animation_plot_table_widget import AnimationPlotsTableWidget
@@ -155,12 +156,12 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         table_bases = cls.CsvSignalsTable._get_data_model_bases()
         return bases + plot_bases + table_bases
 
-    def _write_model(self, model: BaseTopModel) -> None:
+    def _write_model(self, model: BaseModel) -> None:
         super()._write_model(model)
         self._table._write_model(model)
         self._plots._write_model(model)
 
-    def _load_model(self, model: BaseTopModel) -> None:
+    def _load_model(self, model: BaseModel) -> None:
         super()._load_model(model)
         self._table._load_model(model)
         self._plots._load_model(model)

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -69,7 +69,7 @@ class CsvLoaderStateModel(BaseTopModel):
 class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, HasSaveLoadConfig):
     """Example app-level widget that loads CSV files into the plotter"""
 
-    TOP_MODEL_BASES = [CsvLoaderStateModel]
+    _MODEL_BASES = [CsvLoaderStateModel]
 
     WATCH_INTERVAL_MS = 333  # polls the filesystem metadata for changes this frequently
 

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -100,7 +100,7 @@ class MultiPlotWidget(HasSaveLoadDataConfig, QSplitter):
         self._data_name_to_plot_item: Dict[Optional[str], pg.PlotItem] = {None: default_plot_item}
         self._anchor_x_plot_item: pg.PlotItem = default_plot_item  # PlotItem that everyone's x-axis is linked to
 
-    def _write_model(self, model: BaseTopModel) -> None:
+    def _write_model(self, model: BaseModel) -> None:
         super()._write_model(model)
         assert isinstance(model, MultiPlotStateModel)
         model.plot_widgets = []
@@ -130,7 +130,7 @@ class MultiPlotWidget(HasSaveLoadDataConfig, QSplitter):
             else:
                 model.x_range = tuple(x_viewbox.viewRange()[0])
 
-    def _load_model(self, model: BaseTopModel) -> None:
+    def _load_model(self, model: BaseModel) -> None:
         super()._load_model(model)
 
         assert isinstance(model, MultiPlotStateModel)
@@ -376,13 +376,13 @@ class LinkedMultiPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
         self._last_drag_cursor: Optional[float] = None
         super().__init__(*args, **kwargs)
 
-    def _write_model(self, model: BaseTopModel) -> None:
+    def _write_model(self, model: BaseModel) -> None:
         super()._write_model(model)
         assert isinstance(model, LinkedMultiPlotStateModel)
         model.region = self._last_region
         model.pois = self._last_pois
 
-    def _load_model(self, model: BaseTopModel) -> None:
+    def _load_model(self, model: BaseModel) -> None:
         super()._load_model(model)
         assert isinstance(model, LinkedMultiPlotStateModel)
         if model.region is not None:

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -74,7 +74,7 @@ class MultiPlotWidget(HasSaveLoadConfig, QSplitter):
     sigDataItemsUpdated = Signal()  # called when new plot data items are set
     sigDataUpdated = Signal()  # called when new plot data is available
 
-    TOP_MODEL_BASES = [MultiPlotStateModel]
+    _MODEL_BASES = [MultiPlotStateModel]
 
     def __init__(
         self,
@@ -367,7 +367,7 @@ class LinkedMultiPlotStateModel(BaseTopModel):
 class LinkedMultiPlotWidget(MultiPlotWidget, HasSaveLoadConfig):
     """Mixin into the MultiPlotWidget that links PointsOfInterestPlot, RegionPlot, and LiveCursorPlot"""
 
-    TOP_MODEL_BASES = [LinkedMultiPlotStateModel]
+    _MODEL_BASES = [LinkedMultiPlotStateModel]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._last_hover: Optional[float] = None  # must be init'd before the first plot is created in __init__

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 
 from .enum_waveform_plotitem import EnumWaveformPlot
 from .interactivity_mixins import PointsOfInterestPlot, RegionPlot, LiveCursorPlot, DraggableCursorPlot
-from .save_restore_model import HasSaveLoadConfig, BaseTopModel
+from .save_restore_model import BaseTopModel, HasSaveLoadDataConfig
 
 
 class InteractivePlot(DraggableCursorPlot, PointsOfInterestPlot, RegionPlot, LiveCursorPlot):
@@ -53,7 +53,7 @@ class MultiPlotStateModel(BaseTopModel):
     x_range: Optional[Union[Tuple[float, float], Literal["auto"]]] = None
 
 
-class MultiPlotWidget(HasSaveLoadConfig, QSplitter):
+class MultiPlotWidget(HasSaveLoadDataConfig, QSplitter):
     """A splitter that can contain multiple (vertically stacked) plots with linked x-axis"""
 
     class PlotType(Enum):
@@ -364,7 +364,7 @@ class LinkedMultiPlotStateModel(BaseTopModel):
     pois: Optional[List[float]] = None
 
 
-class LinkedMultiPlotWidget(MultiPlotWidget, HasSaveLoadConfig):
+class LinkedMultiPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
     """Mixin into the MultiPlotWidget that links PointsOfInterestPlot, RegionPlot, and LiveCursorPlot"""
 
     _MODEL_BASES = [LinkedMultiPlotStateModel]

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -51,8 +51,8 @@ class HasSaveLoadConfig:
     - where a None is a concrete value, use something else, e.g., empty tuple.
     """
 
-    TOP_MODEL_BASES: List[ModelMetaclass] = []  # defined in subclasses
-    DATA_MODEL_BASES: List[ModelMetaclass] = []
+    _MODEL_BASES: List[ModelMetaclass] = []  # defined in subclasses
+    _DATA_MODEL_BASES: List[ModelMetaclass] = []
 
     @classmethod
     def _get_model_bases(cls) -> Tuple[List[ModelMetaclass], List[ModelMetaclass]]:
@@ -65,9 +65,9 @@ class HasSaveLoadConfig:
         data_model_bases = []
         for base in cls.__mro__:
             if issubclass(base, HasSaveLoadConfig) and "TOP_MODEL_BASES" in base.__dict__:
-                top_model_bases.extend(base.TOP_MODEL_BASES)
+                top_model_bases.extend(base._MODEL_BASES)
             if issubclass(base, HasSaveLoadConfig) and "DATA_MODEL_BASES" in base.__dict__:
-                data_model_bases.extend(base.DATA_MODEL_BASES)
+                data_model_bases.extend(base._DATA_MODEL_BASES)
         return data_model_bases, top_model_bases
 
     @classmethod

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -100,7 +100,7 @@ class HasSaveLoadDataConfig(HasSaveLoadConfig):
     def _get_data_model_bases(cls) -> List[ModelMetaclass]:
         model_bases = []
         for base in cls.__mro__:
-            if issubclass(base, HasSaveLoadConfig) and "_DATA_MODEL_BASES" in base.__dict__:
+            if issubclass(base, HasSaveLoadDataConfig) and "_DATA_MODEL_BASES" in base.__dict__:
                 model_bases.extend(base._DATA_MODEL_BASES)
         return model_bases
 
@@ -122,18 +122,12 @@ class HasSaveLoadDataConfig(HasSaveLoadConfig):
         """Returns an empty model of the correct type (containing all _get_model_bases)
         that can be passed into _save_model."""
         top_model_cls = cls._create_skeleton_model_type()
-        data_model_cls = top_model_cls.model_fields["data"].annotation.__args__[1]
+        data_model_cls = top_model_cls.model_fields["data"].annotation.__args__[1]  # type: ignore
         top_model = top_model_cls(data={data_name: data_model_cls() for data_name in data_names})
-        return top_model
+        return top_model  # type: ignore
 
     def _dump_model(self, data_names: Iterable[str]) -> BaseTopModel:
         """For top-level self, generate the save state model. Convenience wrapper around model creation and writing."""
         model = self._create_skeleton_data_model(data_names)
         self._write_model(model)
         return model
-
-    def _write_model(self, model: BaseTopModel) -> None:
-        pass
-
-    def _load_model(self, model: BaseTopModel) -> None:
-        pass

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -52,9 +52,7 @@ class HasSaveLoadConfig:
     @classmethod
     def _create_skeleton_model_type(cls) -> Type[BaseModel]:
         model_bases = cls._get_model_bases()
-        top_model_cls = pydantic.create_model("TopModel", __base__=tuple(model_bases))  # type: ignore
-
-        return top_model_cls
+        return pydantic.create_model("TopModel", __base__=tuple(model_bases))  # type: ignore
 
     def _dump_model(self) -> BaseModel:
         """For top-level self, generate the save state model. Convenience wrapper around model creation and writing."""

--- a/pyqtgraph_scope_plots/save_restore_model.py
+++ b/pyqtgraph_scope_plots/save_restore_model.py
@@ -56,6 +56,12 @@ class HasSaveLoadConfig:
 
         return top_model_cls
 
+    def _dump_model(self) -> BaseModel:
+        """For top-level self, generate the save state model. Convenience wrapper around model creation and writing."""
+        model = self._create_skeleton_model_type()()
+        self._write_model(model)
+        return model
+
     def _write_model(self, model: BaseModel) -> None:
         """Saves the data into the top-level model. model.data is pre-populated with models for every data item.
         Mutates the model in-place.
@@ -126,8 +132,9 @@ class HasSaveLoadDataConfig(HasSaveLoadConfig):
         top_model = top_model_cls(data={data_name: data_model_cls() for data_name in data_names})
         return top_model  # type: ignore
 
-    def _dump_model(self, data_names: Iterable[str]) -> BaseTopModel:
-        """For top-level self, generate the save state model. Convenience wrapper around model creation and writing."""
+    def _dump_data_model(self, data_names: Iterable[str]) -> BaseTopModel:
+        """For top-level self, generate the save state model, including top-level data items.
+        Convenience wrapper around model creation and writing."""
         model = self._create_skeleton_data_model(data_names)
         self._write_model(model)
         return model

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -23,10 +23,11 @@ import numpy.typing as npt
 from PySide6.QtCore import QMimeData, QPoint, Signal, QObject, QThread
 from PySide6.QtGui import QColor, Qt, QAction, QDrag, QPixmap, QMouseEvent
 from PySide6.QtWidgets import QTableWidgetItem, QTableWidget, QHeaderView, QMenu, QLabel, QColorDialog
+from pydantic import BaseModel
 
 from .cache_dict import IdentityCacheDict
 from .multi_plot_widget import MultiPlotWidget
-from .save_restore_model import DataTopModel, BaseTopModel, HasSaveLoadDataConfig
+from .save_restore_model import BaseTopModel, DataTopModel, HasSaveLoadDataConfig
 from .util import not_none
 
 
@@ -359,7 +360,8 @@ class ColorPickerSignalsTable(ContextMenuSignalsTable, HasSaveLoadDataConfig):
         self._set_color_action = QAction("Set Color", self)
         self._set_color_action.triggered.connect(self._on_set_color)
 
-    def _write_model(self, model: BaseTopModel) -> None:
+    def _write_model(self, model: BaseModel) -> None:
+        assert isinstance(model, BaseTopModel)
         super()._write_model(model)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, ColorPickerDataStateModel)
@@ -367,7 +369,8 @@ class ColorPickerSignalsTable(ContextMenuSignalsTable, HasSaveLoadDataConfig):
             if color is not None:
                 data_model.color = color.name()
 
-    def _load_model(self, model: BaseTopModel) -> None:
+    def _load_model(self, model: BaseModel) -> None:
+        assert isinstance(model, BaseTopModel)
         super()._load_model(model)
         data_name_colors = []
         for data_name, data_model in model.data.items():

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -351,7 +351,7 @@ class ColorPickerSignalsTable(ContextMenuSignalsTable, HasSaveLoadConfig):
     This gets sent as a signal, and an upper must handle plumbing the colors through.
     """
 
-    DATA_MODEL_BASES = [ColorPickerDataStateModel]
+    _DATA_MODEL_BASES = [ColorPickerDataStateModel]
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -26,7 +26,7 @@ from PySide6.QtWidgets import QTableWidgetItem, QTableWidget, QHeaderView, QMenu
 
 from .cache_dict import IdentityCacheDict
 from .multi_plot_widget import MultiPlotWidget
-from .save_restore_model import HasSaveLoadConfig, DataTopModel, BaseTopModel
+from .save_restore_model import DataTopModel, BaseTopModel, HasSaveLoadDataConfig
 from .util import not_none
 
 
@@ -346,7 +346,7 @@ class ColorPickerDataStateModel(DataTopModel):
     color: Optional[str] = None  # QColor name, e.g., '#ffea70' or 'red'
 
 
-class ColorPickerSignalsTable(ContextMenuSignalsTable, HasSaveLoadConfig):
+class ColorPickerSignalsTable(ContextMenuSignalsTable, HasSaveLoadDataConfig):
     """Mixin into SignalsTable that adds a context menu item for the user to change the color.
     This gets sent as a signal, and an upper must handle plumbing the colors through.
     """

--- a/pyqtgraph_scope_plots/timeshift_signals_table.py
+++ b/pyqtgraph_scope_plots/timeshift_signals_table.py
@@ -18,9 +18,10 @@ import numpy as np
 import numpy.typing as npt
 from PySide6.QtGui import QAction, QColor
 from PySide6.QtWidgets import QTableWidgetItem, QMenu
+from pydantic import BaseModel
 
 from .cache_dict import IdentityCacheDict
-from .save_restore_model import DataTopModel, BaseTopModel, HasSaveLoadDataConfig
+from .save_restore_model import DataTopModel, HasSaveLoadDataConfig, BaseTopModel
 from .signals_table import ContextMenuSignalsTable
 from .util import not_none
 
@@ -49,14 +50,16 @@ class TimeshiftSignalsTable(ContextMenuSignalsTable, HasSaveLoadDataConfig):
             npt.NDArray[np.float64], npt.NDArray[np.float64]
         ]()  # src x-values -> output x-values
 
-    def _write_model(self, model: BaseTopModel) -> None:
+    def _write_model(self, model: BaseModel) -> None:
+        assert isinstance(model, BaseTopModel)
         super()._write_model(model)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, TimeshiftDataStateModel)
             timeshift = self._timeshifts.get(data_name, 0)
             data_model.timeshift = timeshift
 
-    def _load_model(self, model: BaseTopModel) -> None:
+    def _load_model(self, model: BaseModel) -> None:
+        assert isinstance(model, BaseTopModel)
         super()._load_model(model)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, TimeshiftDataStateModel)

--- a/pyqtgraph_scope_plots/timeshift_signals_table.py
+++ b/pyqtgraph_scope_plots/timeshift_signals_table.py
@@ -36,7 +36,7 @@ class TimeshiftSignalsTable(ContextMenuSignalsTable, HasSaveLoadConfig):
     that gets its data from the user dragging a plot line)."""
 
     COL_TIMESHIFT = -1
-    DATA_MODEL_BASES = [TimeshiftDataStateModel]
+    _DATA_MODEL_BASES = [TimeshiftDataStateModel]
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)

--- a/pyqtgraph_scope_plots/timeshift_signals_table.py
+++ b/pyqtgraph_scope_plots/timeshift_signals_table.py
@@ -20,7 +20,7 @@ from PySide6.QtGui import QAction, QColor
 from PySide6.QtWidgets import QTableWidgetItem, QMenu
 
 from .cache_dict import IdentityCacheDict
-from .save_restore_model import DataTopModel, HasSaveLoadConfig, BaseTopModel
+from .save_restore_model import DataTopModel, BaseTopModel, HasSaveLoadDataConfig
 from .signals_table import ContextMenuSignalsTable
 from .util import not_none
 
@@ -29,7 +29,7 @@ class TimeshiftDataStateModel(DataTopModel):
     timeshift: Optional[float] = None
 
 
-class TimeshiftSignalsTable(ContextMenuSignalsTable, HasSaveLoadConfig):
+class TimeshiftSignalsTable(ContextMenuSignalsTable, HasSaveLoadDataConfig):
     """Mixin into SignalsTable that adds a UI to time-shift a signal.
     This acts as the data store and transformer to apply the time-shift, but the actual
     values are set externally (by a function call, typically from the top-level coordinator

--- a/pyqtgraph_scope_plots/transforms_signal_table.py
+++ b/pyqtgraph_scope_plots/transforms_signal_table.py
@@ -21,8 +21,8 @@ import simpleeval
 from PySide6.QtGui import QColor, QAction
 from PySide6.QtWidgets import QTableWidgetItem, QMenu, QInputDialog, QLineEdit
 
-from .save_restore_model import DataTopModel, HasSaveLoadConfig, BaseTopModel
 from .cache_dict import IdentityCacheDict
+from .save_restore_model import DataTopModel, BaseTopModel, HasSaveLoadDataConfig
 from .signals_table import ContextMenuSignalsTable
 from .util import not_none
 
@@ -31,7 +31,7 @@ class TransformsDataStateModel(DataTopModel):
     transform: Optional[str] = None
 
 
-class TransformsSignalsTable(ContextMenuSignalsTable, HasSaveLoadConfig):
+class TransformsSignalsTable(ContextMenuSignalsTable, HasSaveLoadDataConfig):
     """Mixin into SignalsTable that adds a UI for the user to specify a transform using a subset of Python code.
     This parses the user input and provides a get_transform."""
 

--- a/pyqtgraph_scope_plots/transforms_signal_table.py
+++ b/pyqtgraph_scope_plots/transforms_signal_table.py
@@ -36,7 +36,7 @@ class TransformsSignalsTable(ContextMenuSignalsTable, HasSaveLoadConfig):
     This parses the user input and provides a get_transform."""
 
     COL_TRANSFORM = -1
-    DATA_MODEL_BASES = [TransformsDataStateModel]
+    _DATA_MODEL_BASES = [TransformsDataStateModel]
 
     class AllDataDict:
         """Takes in multiple series of (xs, ys) and returns the value at exactly the current x.

--- a/pyqtgraph_scope_plots/transforms_signal_table.py
+++ b/pyqtgraph_scope_plots/transforms_signal_table.py
@@ -20,9 +20,10 @@ import numpy.typing as npt
 import simpleeval
 from PySide6.QtGui import QColor, QAction
 from PySide6.QtWidgets import QTableWidgetItem, QMenu, QInputDialog, QLineEdit
+from pydantic import BaseModel
 
 from .cache_dict import IdentityCacheDict
-from .save_restore_model import DataTopModel, BaseTopModel, HasSaveLoadDataConfig
+from .save_restore_model import DataTopModel, HasSaveLoadDataConfig, BaseTopModel
 from .signals_table import ContextMenuSignalsTable
 from .util import not_none
 
@@ -89,14 +90,16 @@ class TransformsSignalsTable(ContextMenuSignalsTable, HasSaveLoadDataConfig):
             npt.NDArray[np.float64], npt.NDArray[np.float64]
         ]()  # src data -> output data
 
-    def _write_model(self, model: BaseTopModel) -> None:
+    def _write_model(self, model: BaseModel) -> None:
+        assert isinstance(model, BaseTopModel)
         super()._write_model(model)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, TransformsDataStateModel)
             transform, _ = self._transforms.get(data_name, ("", None))
             data_model.transform = transform
 
-    def _load_model(self, model: BaseTopModel) -> None:
+    def _load_model(self, model: BaseModel) -> None:
+        assert isinstance(model, BaseTopModel)
         super()._load_model(model)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, TransformsDataStateModel)

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from typing import List, Tuple, Optional, Literal, Union, cast, Any
+from typing import List, Tuple, Optional, Literal, Union, cast, Any, Dict, Sequence
 
 import numpy as np
 import pyqtgraph as pg
@@ -55,11 +55,13 @@ class BaseXyPlot:
 class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
     FADE_SEGMENTS = 16
 
-    sigXysChanged = Signal()
+    sigXyDataItemsChanged = Signal()
+    sigXyDataChanged = Signal()
 
     def __init__(self, plots: MultiPlotWidget):
         super().__init__(plots)
         self._xys: List[Tuple[str, str]] = []
+        self._data: Dict[str, Sequence[float]] = {}  # data, post alignment and truncation to regions
 
         self._drag_overlays: List[DragTargetOverlay] = []
         self.setAcceptDrops(True)
@@ -97,7 +99,7 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
         if (x_name, y_name) not in self._xys:
             self._xys.append((x_name, y_name))
             self._update()
-        self.sigXysChanged.emit()
+        self.sigXyDataItemsChanged.emit()
 
     @staticmethod
     def _get_correlated_indices(
@@ -237,7 +239,7 @@ class XyPlotTable(QTableWidget):
         self._xy_plots = xy_plots
 
         self._plots.sigDataItemsUpdated.connect(self._update)
-        self._xy_plots.sigXysChanged.connect(self._update)
+        self._xy_plots.sigXyDataItemsChanged.connect(self._update)
 
         self.setColumnCount(2)
         self.setHorizontalHeaderItem(self.COL_X_NAME, QTableWidgetItem("X"))

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -35,6 +35,8 @@ class XyWindowModel(BaseModel):
 class BaseXyPlot:
     """Abstract interface for a XY plot widget"""
 
+    closed = Signal()
+
     def __init__(self, plots: MultiPlotWidget):
         super().__init__()
         self._plots = plots

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -12,13 +12,13 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from typing import List, Tuple, Optional, Literal, Union, cast
+from typing import List, Tuple, Optional, Literal, Union, cast, Any
 
 import numpy as np
 import pyqtgraph as pg
-from PySide6.QtCore import QSize, Signal
-from PySide6.QtGui import QColor, QDragMoveEvent, QDragLeaveEvent, QDropEvent
-from PySide6.QtWidgets import QMessageBox, QWidget, QTableWidget, QTableWidgetItem
+from PySide6.QtCore import QSize, Signal, QPoint
+from PySide6.QtGui import QColor, QDragMoveEvent, QDragLeaveEvent, QDropEvent, Qt
+from PySide6.QtWidgets import QMessageBox, QWidget, QTableWidget, QTableWidgetItem, QMenu
 from numpy import typing as npt
 from pydantic import BaseModel
 
@@ -260,3 +260,21 @@ class XyPlotTable(QTableWidget):
             if y_color is not None:
                 y_item.setForeground(y_color)
             self.setItem(row, self.COL_Y_NAME, y_item)
+
+
+class ContextMenuXyPlotTable(XyPlotTable):
+    """Mixin into XyPlotTable that adds a context menu on rows."""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.customContextMenuRequested.connect(self._spawn_table_cell_menu)
+
+    def _spawn_table_cell_menu(self, pos: QPoint) -> None:
+        menu = QMenu(self)
+        self._populate_context_menu(menu)
+        menu.popup(self.mapToGlobal(pos))
+
+    def _populate_context_menu(self, menu: QMenu) -> None:
+        """Called when the context menu is created, to populate its items."""
+        pass

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -38,6 +38,7 @@ class RefGeoXyPlotWidget(XyPlotWidget):
         self._simpleeval = simpleeval.EvalWithCompoundTypes(functions=self._SIMPLEEVAL_FNS)
 
     def add_ref_geometry_fn(self, expr_str: str) -> None:
+        """Adds a reference geometry function. Can raise SyntaxError on a parsing failure."""
         if len(expr_str) == 0:
             return
         parsed = self._simpleeval.parse(expr_str)

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -31,7 +31,7 @@ class RefGeoXyPlotWidget(XyPlotWidget):
     """Mixin into XyPlotWidget that adds support for reference geometry as a polyline.
     For signal purposes, reference geometry is counted as a data item change."""
 
-    _SIMPLEEVAL_FNS: Dict[str, Callable] = {
+    _SIMPLEEVAL_FNS: Dict[str, Callable[[Any], Any]] = {
         "polyline": _refgeo_polyline_fn
     }  # optional additional available in refgeo expressions
 

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -130,7 +130,7 @@ class RefGeoXyPlotTable(ContextMenuXyPlotTable, XyPlotTable):
             text, ok = QInputDialog().getText(
                 self,
                 "Add reference geometry",
-                "Function for reference geometry, as a tuple of xs, ys, for example '([0, 1], [0, 1])' for a diagonal line. \n"
+                "Function for reference geometry, as (xs, ys), for example '([0, 1], [0, 1])' for a diagonal line. \n"
                 # "Use 'data['...']' or 'data.get('...') to access the data sequence (bounded to the selected region) by name. \n"  # TODO
                 "These helper functions are available: \n" + fn_help_str + err_msg,
                 QLineEdit.EchoMode.Normal,

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -22,7 +22,7 @@ from .xy_plot import XyPlotWidget, XyPlotTable, ContextMenuXyPlotTable
 
 
 def _refgeo_polyline_fn(*pts: Tuple[float, float]) -> Tuple[Sequence[float], Sequence[float]]:
-    """turns of sequence of (x, y) points into (xs, ys)"""
+    """polyline(*pts: (x, y)) -> (xs, ys): turns of sequence of (x, y) points into (xs, ys)"""
     return [pt[0] for pt in pts], [pt[1] for pt in pts]
 
 
@@ -77,7 +77,7 @@ class RefGeoXyPlotTable(ContextMenuXyPlotTable, XyPlotTable):
         assert isinstance(self._xy_plots, RefGeoXyPlotWidget)
         text = ""
         err_msg = ""
-        fn_help_str = "\n".join([f"{fn_name}: {fn.__doc__}" for fn_name, fn in self._xy_plots._SIMPLEEVAL_FNS.items()])
+        fn_help_str = "\n".join([f"- {fn.__doc__}" for fn_name, fn in self._xy_plots._SIMPLEEVAL_FNS.items()])
         while True:
             text, ok = QInputDialog().getText(
                 self,

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -53,7 +53,6 @@ class RefGeoXyPlotWidget(XyPlotWidget):
             self._simpleeval.names = {
                 # "data": other_data_dict,  # TODO support aligned data
             }
-
             xs, ys = self._simpleeval.eval(refgeo_expr, refgeo_parsed)
             curve = pg.PlotCurveItem(x=xs, y=ys)
             self.addItem(curve)

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+from typing import Any, List, Tuple, Dict, Sequence
+
+import simpleeval
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import QMenu
+import pyqtgraph as pg
+
+from .xy_plot import XyPlotWidget, XyPlotTable, ContextMenuXyPlotTable
+
+
+def _refgeo_polyline_fn(*pts: Tuple[float, float]) -> Tuple[Sequence[float], Sequence[float]]:
+    return [pt[0] for pt in pts], [pt[1] for pt in pts]
+
+
+class RefGeoXyPlotWidget(XyPlotWidget):
+    """Mixin into XyPlotWidget that adds support for reference geometry as a polyline."""
+
+    _SIMPLEEVAL_FNS: Dict[str, Any] = {
+        "polyline": _refgeo_polyline_fn
+    }  # optional additional available in refgeo expressions
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._ref_geometry_fns: List[Tuple[str, Any]] = []  # (expr str, parsed)
+        self._simpleeval = simpleeval.EvalWithCompoundTypes(functions=self._SIMPLEEVAL_FNS)
+
+    def add_ref_geometry_fn(self, expr_str: str) -> None:
+        if len(expr_str) == 0:
+            return
+        parsed = self._simpleeval.parse(expr_str)
+        self._ref_geometry_fns.append((expr_str, parsed))
+        self._update()
+
+    def _update(self) -> None:
+        super()._update()  # data items drawn here
+
+        # draw reference geometry
+        for refgeo_expr, refgeo_parsed in self._ref_geometry_fns:
+            self._simpleeval.names = {
+                # "data": other_data_dict,  # TODO support aligned data
+            }
+
+            xs, ys = self._simpleeval.eval(refgeo_expr, refgeo_parsed)
+            curve = pg.PlotCurveItem(x=xs, y=ys)
+            self.addItem(curve)
+
+
+class RefGeoXyPlotTable(ContextMenuXyPlotTable, XyPlotTable):
+    """Mixin into XyPlotTable that adds support for reference geometry construction"""
+
+    def _populate_context_menu(self, menu: QMenu) -> None:
+        """Called when the context menu is created, to populate its items."""
+        super()._populate_context_menu(menu)
+        add_refgeo = QAction("Add reference geometry", self)
+        add_refgeo.triggered.connect(self._on_add_refgeo)
+        menu.addAction(add_refgeo)
+
+    def _on_add_refgeo(self) -> None:
+        raise NotImplementedError  # TODO IMPLEMENT ME

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -24,7 +24,7 @@ from .xy_plot_refgeo import RefGeoXyPlotTable, RefGeoXyPlotWidget
 
 
 class XyPlotSplitter(BaseXyPlot, QSplitter):
-    """XY plot splitter with a table that otherwise passes the BaseXyPlot interface items to its plot."""
+    """XY plot splitter with a table that otherwise delegates the BaseXyPlot interface items to its plot."""
 
     class FullXyPlotWidget(RefGeoXyPlotWidget, XyDragDroppable, XyPlotWidget):  # only for mixin composition
         pass
@@ -55,6 +55,9 @@ class XyPlotSplitter(BaseXyPlot, QSplitter):
 
     def add_xy(self, x_name: str, y_name: str) -> None:
         self._xy_plots.add_xy(x_name, y_name)
+
+    def _create_skeleton_model_type(cls) -> Type[BaseModel]:
+        return cls._xy_plots._create_skeleton_model_type()
 
     def _write_model(self, model: BaseModel) -> None:
         self._xy_plots._write_model(model)

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -26,8 +26,6 @@ from .xy_plot_refgeo import RefGeoXyPlotTable, RefGeoXyPlotWidget
 class XyPlotSplitter(BaseXyPlot, QSplitter):
     """XY plot splitter with a table that otherwise passes the BaseXyPlot interface items to its plot."""
 
-    closed = Signal()
-
     class FullXyPlotWidget(RefGeoXyPlotWidget, XyDragDroppable, XyPlotWidget):  # only for mixin composition
         pass
 

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -56,8 +56,9 @@ class XyPlotSplitter(BaseXyPlot, QSplitter):
     def add_xy(self, x_name: str, y_name: str) -> None:
         self._xy_plots.add_xy(x_name, y_name)
 
+    @classmethod
     def _create_skeleton_model_type(cls) -> Type[BaseModel]:
-        return cls._xy_plots._create_skeleton_model_type()
+        return cls._XY_PLOT_TYPE._create_skeleton_model_type()
 
     def _write_model(self, model: BaseModel) -> None:
         self._xy_plots._write_model(model)

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -15,47 +15,11 @@ from typing import Type
 
 from PySide6 import QtGui
 from PySide6.QtCore import Qt, Signal
-from PySide6.QtWidgets import QSplitter, QTableWidget, QTableWidgetItem
+from PySide6.QtWidgets import QSplitter
 from pydantic import BaseModel
 
 from .multi_plot_widget import MultiPlotWidget
-from .signals_table import SignalsTable
-from .xy_plot import BaseXyPlot, XyPlotWidget, XyDragDroppable
-
-
-class XyPlotTable(QTableWidget):
-    COL_X_NAME: int = 0
-    COL_Y_NAME: int = 1
-
-    def __init__(self, plots: MultiPlotWidget, xy_plots: XyPlotWidget):
-        super().__init__()
-        self._plots = plots
-        self._xy_plots = xy_plots
-
-        self._plots.sigDataItemsUpdated.connect(self._update)
-        self._xy_plots.sigXysChanged.connect(self._update)
-
-        self.setColumnCount(2)
-        self.setHorizontalHeaderItem(self.COL_X_NAME, QTableWidgetItem("X"))
-        self.setHorizontalHeaderItem(self.COL_Y_NAME, QTableWidgetItem("Y"))
-
-    def _update(self) -> None:
-        self.setRowCount(0)  # clear table
-        self.setRowCount(len(self._xy_plots._xys))
-        for row, (x_name, y_name) in enumerate(self._xy_plots._xys):
-            x_item = SignalsTable._create_noneditable_table_item()
-            x_item.setText(x_name)
-            x_color, _ = self._plots._data_items.get(x_name, (None, None))
-            if x_color is not None:
-                x_item.setForeground(x_color)
-            self.setItem(row, self.COL_X_NAME, x_item)
-
-            y_item = SignalsTable._create_noneditable_table_item()
-            y_item.setText(y_name)
-            y_color, _ = self._plots._data_items.get(y_name, (None, None))
-            if y_color is not None:
-                y_item.setForeground(y_color)
-            self.setItem(row, self.COL_Y_NAME, y_item)
+from .xy_plot import BaseXyPlot, XyPlotWidget, XyDragDroppable, XyPlotTable
 
 
 class XyPlotSplitter(BaseXyPlot, QSplitter):

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 
 from .multi_plot_widget import MultiPlotWidget
 from .xy_plot import BaseXyPlot, XyPlotWidget, XyDragDroppable, XyPlotTable
+from .xy_plot_refgeo import RefGeoXyPlotTable, RefGeoXyPlotWidget
 
 
 class XyPlotSplitter(BaseXyPlot, QSplitter):
@@ -27,11 +28,14 @@ class XyPlotSplitter(BaseXyPlot, QSplitter):
 
     closed = Signal()
 
-    class FullXyPlotWidget(XyDragDroppable, XyPlotWidget):  # only for mixin composition
+    class FullXyPlotWidget(RefGeoXyPlotWidget, XyDragDroppable, XyPlotWidget):  # only for mixin composition
+        pass
+
+    class FullXyPlotTable(RefGeoXyPlotTable, XyPlotTable):  # only for mixin composition
         pass
 
     _XY_PLOT_TYPE: Type[XyPlotWidget] = FullXyPlotWidget
-    _XY_PLOT_TABLE_TYPE: Type[XyPlotTable] = XyPlotTable
+    _XY_PLOT_TABLE_TYPE: Type[XyPlotTable] = FullXyPlotTable
 
     def _make_xy_plots(self) -> XyPlotWidget:
         """Creates the XyPlot widget. self._plots is initialized by this time.

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -32,7 +32,7 @@ class XyTable(
 ):
     """Mixin into SignalsTable that adds the option to open an XY plot in a separate window."""
 
-    TOP_MODEL_BASES = [XyTableStateModel]
+    _MODEL_BASES = [XyTableStateModel]
     _XY_PLOT_TYPE: Type[BaseXyPlot] = XyPlotSplitter
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -21,11 +21,12 @@ from pydantic import BaseModel
 from .save_restore_model import BaseTopModel, HasSaveLoadDataConfig
 from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable, DraggableSignalsTable
 from .xy_plot import BaseXyPlot, XyWindowModel
+from .xy_plot_refgeo import XyRefGeoModel
 from .xy_plot_splitter import XyPlotSplitter
 
 
 class XyTableStateModel(BaseTopModel):
-    xy_windows: Optional[List[XyWindowModel]] = None
+    xy_windows: Optional[List[XyRefGeoModel]] = None
 
 
 class XyTable(

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -17,7 +17,7 @@ from typing import Any, List, Optional, Type
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QMessageBox, QWidget
 
-from .save_restore_model import HasSaveLoadConfig, BaseTopModel
+from .save_restore_model import BaseTopModel, HasSaveLoadDataConfig
 from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable, DraggableSignalsTable
 from .xy_plot import BaseXyPlot, XyWindowModel
 from .xy_plot_splitter import XyPlotSplitter
@@ -28,7 +28,7 @@ class XyTableStateModel(BaseTopModel):
 
 
 class XyTable(
-    DraggableSignalsTable, ContextMenuSignalsTable, HasRegionSignalsTable, HasDataSignalsTable, HasSaveLoadConfig
+    DraggableSignalsTable, ContextMenuSignalsTable, HasRegionSignalsTable, HasDataSignalsTable, HasSaveLoadDataConfig
 ):
     """Mixin into SignalsTable that adds the option to open an XY plot in a separate window."""
 

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -48,8 +48,7 @@ class XyTable(
         assert isinstance(model, XyTableStateModel)
         model.xy_windows = []
         for xy_plot in self._xy_plots:
-            model.xy_windows.append(XyWindowModel())
-            xy_plot._write_model(model.xy_windows[-1])
+            model.xy_windows.append(xy_plot._dump_model())  # type: ignore
 
     def _load_model(self, model: BaseModel) -> None:
         super()._load_model(model)

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -16,6 +16,7 @@ from typing import Any, List, Optional, Type
 
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QMessageBox, QWidget
+from pydantic import BaseModel
 
 from .save_restore_model import BaseTopModel, HasSaveLoadDataConfig
 from .signals_table import ContextMenuSignalsTable, HasDataSignalsTable, HasRegionSignalsTable, DraggableSignalsTable
@@ -41,7 +42,7 @@ class XyTable(
         self._xy_action.triggered.connect(self._on_create_xy)
         self._xy_plots: List[BaseXyPlot] = []
 
-    def _write_model(self, model: BaseTopModel) -> None:
+    def _write_model(self, model: BaseModel) -> None:
         super()._write_model(model)
         assert isinstance(model, XyTableStateModel)
         model.xy_windows = []
@@ -49,7 +50,7 @@ class XyTable(
             model.xy_windows.append(XyWindowModel())
             xy_plot._write_model(model.xy_windows[-1])
 
-    def _load_model(self, model: BaseTopModel) -> None:
+    def _load_model(self, model: BaseModel) -> None:
         super()._load_model(model)
         assert isinstance(model, XyTableStateModel)
         if model.xy_windows is None:

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -208,7 +208,7 @@ def test_plot_remove(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
 def test_plot_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     qtbot.waitUntil(
-        lambda: cast(MultiPlotStateModel, plot._plots._dump_model([])).plot_widgets
+        lambda: cast(MultiPlotStateModel, plot._plots._dump_data_model([])).plot_widgets
         == [
             PlotWidgetModel(data_items=["0"], y_range="auto"),
             PlotWidgetModel(data_items=["1"], y_range="auto"),
@@ -218,19 +218,19 @@ def test_plot_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
     plot._plots._merge_data_into_item(["0"], 1)  # merge
     qtbot.waitUntil(
-        lambda: cast(MultiPlotStateModel, plot._plots._dump_model([])).plot_widgets
+        lambda: cast(MultiPlotStateModel, plot._plots._dump_data_model([])).plot_widgets
         == [PlotWidgetModel(data_items=["1", "0"], y_range="auto"), PlotWidgetModel(data_items=["2"], y_range="auto")]
     )
 
     plot._plots._merge_data_into_item(["2"], 0)  # merge
     qtbot.waitUntil(
-        lambda: cast(MultiPlotStateModel, plot._plots._dump_model([])).plot_widgets
+        lambda: cast(MultiPlotStateModel, plot._plots._dump_data_model([])).plot_widgets
         == [PlotWidgetModel(data_items=["1", "0", "2"], y_range="auto")]
     )
 
 
 def test_plot_restore(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    model = cast(MultiPlotStateModel, plot._plots._dump_model([]))
+    model = cast(MultiPlotStateModel, plot._plots._dump_data_model([]))
     model.plot_widgets = [PlotWidgetModel(data_items=["0", "1", "2"])]
     plot._plots._load_model(model)
     plot._plots.set_data(plot._plots._data)  # bulk update that happens at top level
@@ -252,7 +252,7 @@ def test_plot_restore(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
 
 def test_plot_restore_range(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    model = cast(MultiPlotStateModel, plot._plots._dump_model([]))
+    model = cast(MultiPlotStateModel, plot._plots._dump_data_model([]))
     model.plot_widgets = [PlotWidgetModel(data_items=["0"])]
     model.x_range = (-10, 42)
     plot._plots._load_model(model)

--- a/tests/test_linked_plot.py
+++ b/tests/test_linked_plot.py
@@ -59,17 +59,17 @@ def test_linked_region(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
 
 def test_region_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_model([])).region is None)
+    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_data_model([])).region is None)
 
     plot_item(plot, 0).set_region((0.1, 1.5))
-    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_model([])).region == (0.1, 1.5))
+    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_data_model([])).region == (0.1, 1.5))
 
     plot_item(plot, 1).set_region(1.0)
-    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_model([])).region == 1.0)
+    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_data_model([])).region == 1.0)
 
 
 def test_region_restore(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    model = cast(LinkedMultiPlotStateModel, plot._plots._dump_model([]))
+    model = cast(LinkedMultiPlotStateModel, plot._plots._dump_data_model([]))
 
     model.region = (0.1, 1.5)
     plot._plots._load_model(model)
@@ -110,14 +110,14 @@ def test_linked_pois(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
 
 def test_pois_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_model([])).pois == [])
+    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_data_model([])).pois == [])
 
     plot_item(plot, 0).set_pois([0.1, 1.5])
-    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_model([])).pois == [0.1, 1.5])
+    qtbot.waitUntil(lambda: cast(LinkedMultiPlotStateModel, plot._plots._dump_data_model([])).pois == [0.1, 1.5])
 
 
 def test_pois_restore(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    model = cast(LinkedMultiPlotStateModel, plot._plots._dump_model([]))
+    model = cast(LinkedMultiPlotStateModel, plot._plots._dump_data_model([]))
 
     model.pois = [0.1, 1.5]
     plot._plots._load_model(model)

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -19,7 +19,6 @@ from pydantic import BaseModel
 from pyqtgraph_scope_plots.save_restore_model import (
     DataTopModel,
     BaseTopModel,
-    HasSaveLoadConfig,
     HasSaveLoadDataConfig,
 )
 
@@ -58,7 +57,7 @@ class SaveRestoreSub(HasSaveLoadDataConfig):
         self.base_field1 = 2.0
         self.inner_a_field = "a"
 
-    def _write_model(self, model: BaseTopModel) -> None:
+    def _write_model(self, model: BaseModel) -> None:
         super()._write_model(model)
 
         assert isinstance(model, BaseModelSub1) and isinstance(model, BaseModelSub2)
@@ -70,7 +69,7 @@ class SaveRestoreSub(HasSaveLoadDataConfig):
         model.base_field1 = self.base_field1
         model.inner.a_field = self.inner_a_field
 
-    def _load_model(self, model: BaseTopModel) -> None:
+    def _load_model(self, model: BaseModel) -> None:
         super()._load_model(model)
 
         assert isinstance(model, BaseModelSub1) and isinstance(model, BaseModelSub2)

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -40,8 +40,8 @@ class BaseModelSub2(BaseTopModel):
 
 
 class SaveRestoreSub(HasSaveLoadConfig):
-    TOP_MODEL_BASES = [BaseModelSub1, BaseModelSub2]
-    DATA_MODEL_BASES = [DataModelSub1, DataModelSub2]
+    _MODEL_BASES = [BaseModelSub1, BaseModelSub2]
+    _DATA_MODEL_BASES = [DataModelSub1, DataModelSub2]
 
     def __init__(self, data_names: Iterable[str]):
         self.data_field1s = {}

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -16,7 +16,12 @@ from typing import Optional, Iterable, cast, Dict
 
 from pydantic import BaseModel
 
-from pyqtgraph_scope_plots.save_restore_model import DataTopModel, BaseTopModel, HasSaveLoadConfig
+from pyqtgraph_scope_plots.save_restore_model import (
+    DataTopModel,
+    BaseTopModel,
+    HasSaveLoadConfig,
+    HasSaveLoadDataConfig,
+)
 
 
 class DataModelSub1(DataTopModel):
@@ -39,7 +44,7 @@ class BaseModelSub2(BaseTopModel):
     inner: InnerModel = InnerModel()
 
 
-class SaveRestoreSub(HasSaveLoadConfig):
+class SaveRestoreSub(HasSaveLoadDataConfig):
     _MODEL_BASES = [BaseModelSub1, BaseModelSub2]
     _DATA_MODEL_BASES = [DataModelSub1, DataModelSub2]
 
@@ -81,7 +86,7 @@ class SaveRestoreSub(HasSaveLoadConfig):
 def test_save_model() -> None:
     """Tests composition of the save model"""
     instance = SaveRestoreSub(["data1", "data2", "data3"])
-    skeleton = instance._create_skeleton_model(instance.data_field1s.keys())
+    skeleton = instance._create_skeleton_data_model(instance.data_field1s.keys())
 
     assert isinstance(skeleton, BaseModelSub1) and isinstance(skeleton, BaseModelSub2)
     assert isinstance(skeleton.data["data1"], DataModelSub1) and isinstance(skeleton.data["data1"], DataModelSub2)
@@ -106,7 +111,7 @@ def test_save_model() -> None:
 
 def test_load_model() -> None:
     instance = SaveRestoreSub(["data1", "data2", "data3"])
-    model = instance._create_skeleton_model(instance.data_field1s.keys())
+    model = instance._create_skeleton_data_model(instance.data_field1s.keys())
     cast(DataModelSub2, model.data["data3"]).field2 = "quack"
 
     instance._load_model(model)

--- a/tests/test_transforms_timeshift_table.py
+++ b/tests/test_transforms_timeshift_table.py
@@ -152,22 +152,22 @@ def test_transform_ui_error(qtbot: QtBot, transforms_table: TransformsSignalsTab
 
 
 def test_transform_save(qtbot: QtBot, transforms_table: TransformsSignalsTable) -> None:
-    assert cast(TransformsDataStateModel, transforms_table._dump_model(["0", "1"]).data["0"]).transform == ""
-    assert cast(TransformsDataStateModel, transforms_table._dump_model(["0", "1"]).data["1"]).transform == ""
+    assert cast(TransformsDataStateModel, transforms_table._dump_data_model(["0", "1"]).data["0"]).transform == ""
+    assert cast(TransformsDataStateModel, transforms_table._dump_data_model(["0", "1"]).data["1"]).transform == ""
 
     transforms_table.set_transform(["1"], "x + data['0']")  # allow getting with longer data
     qtbot.waitUntil(
-        lambda: cast(TransformsDataStateModel, transforms_table._dump_model(["0", "1"]).data["1"]).transform
+        lambda: cast(TransformsDataStateModel, transforms_table._dump_data_model(["0", "1"]).data["1"]).transform
         == "x + data['0']"
     )
     assert (
-        cast(TransformsDataStateModel, transforms_table._dump_model(["0", "1"]).data["0"]).transform == ""
+        cast(TransformsDataStateModel, transforms_table._dump_data_model(["0", "1"]).data["0"]).transform == ""
     )  # unchanged
 
 
 def test_transform_load(qtbot: QtBot, transforms_table: TransformsSignalsTable) -> None:
     """Tests transforms that only reference x"""
-    model = transforms_table._dump_model(["0"])
+    model = transforms_table._dump_data_model(["0"])
 
     cast(TransformsDataStateModel, model.data["0"]).transform = "x + 1"
     transforms_table._load_model(model)
@@ -193,15 +193,17 @@ def test_timeshift(qtbot: QtBot, timeshifts_table: TimeshiftSignalsTable) -> Non
 
 
 def test_timeshift_save(qtbot: QtBot, timeshifts_table: TimeshiftSignalsTable) -> None:
-    qtbot.waitUntil(lambda: cast(TimeshiftDataStateModel, timeshifts_table._dump_model(["0"]).data["0"]).timeshift == 0)
+    qtbot.waitUntil(
+        lambda: cast(TimeshiftDataStateModel, timeshifts_table._dump_data_model(["0"]).data["0"]).timeshift == 0
+    )
     timeshifts_table.set_timeshift(["0"], -0.5)
     qtbot.waitUntil(
-        lambda: cast(TimeshiftDataStateModel, timeshifts_table._dump_model(["0"]).data["0"]).timeshift == -0.5
+        lambda: cast(TimeshiftDataStateModel, timeshifts_table._dump_data_model(["0"]).data["0"]).timeshift == -0.5
     )
 
 
 def test_timeshift_load(qtbot: QtBot, timeshifts_table: TimeshiftSignalsTable) -> None:
-    model = timeshifts_table._dump_model(["0"])
+    model = timeshifts_table._dump_data_model(["0"])
     cast(TimeshiftDataStateModel, model.data["0"]).timeshift = -0.5
     timeshifts_table._load_model(model)
     qtbot.waitUntil(lambda: timeshifts_table.apply_timeshifts("0", DATA).tolist() == [-0.5, -0.4, 0.5, 1.5])

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -11,6 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+
 from typing import cast
 
 import numpy as np

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -89,7 +89,7 @@ def test_xy_create_ui(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     plot._table.item(1, 0).setSelected(True)
     plot._table.item(0, 0).setSelected(True)
     xy_plot = cast(XyPlotSplitter, plot._table._on_create_xy())
-    qtbot.waitSignal(xy_plot._xy_plots.sigXysChanged)
+    qtbot.waitSignal(xy_plot._xy_plots.sigXyDataItemsChanged)
     assert xy_plot is not None
     assert xy_plot._xy_plots._xys == [("1", "0")]
 
@@ -97,7 +97,7 @@ def test_xy_create_ui(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     plot._table.item(0, 0).setSelected(True)
     plot._table.item(1, 0).setSelected(True)
     xy_plot = cast(XyPlotSplitter, plot._table._on_create_xy())
-    qtbot.waitSignal(xy_plot._xy_plots.sigXysChanged)
+    qtbot.waitSignal(xy_plot._xy_plots.sigXyDataItemsChanged)
     assert xy_plot is not None
     assert xy_plot._xy_plots._xys == [("0", "1")]
 

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -21,7 +21,9 @@ from pytestqt.qtbot import QtBot
 
 from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
+from pyqtgraph_scope_plots.util import not_none
 from pyqtgraph_scope_plots.xy_plot import XyPlotWidget, XyWindowModel
+from pyqtgraph_scope_plots.xy_plot_refgeo import XyRefGeoModel
 from pyqtgraph_scope_plots.xy_plot_splitter import XyPlotSplitter
 from pyqtgraph_scope_plots.xy_plot_table import XyTableStateModel
 
@@ -104,6 +106,14 @@ def test_xy_create_ui(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     qtbot.wait(10)  # wait for rendering to happen
 
 
+def test_xy_close_cleanup(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+    xy_plot = cast(XyPlotSplitter, plot._table.create_xy())
+    xy_plot.add_xy("0", "2")
+    qtbot.waitUntil(lambda: len(plot._table._xy_plots) > 0)
+    xy_plot.close()
+    qtbot.waitUntil(lambda: not plot._table._xy_plots)
+
+
 def test_xy_offset(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     xy_plot = cast(XyPlotSplitter, plot._table.create_xy())
     xy_plot.add_xy("0", "2")
@@ -117,16 +127,15 @@ def test_xy_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     xy_plot = plot._table.create_xy()
     xy_plot.add_xy("0", "1")
     xy_plot.add_xy("1", "0")
-    qtbot.waitUntil(
-        lambda: cast(XyTableStateModel, plot._table._dump_data_model([])).xy_windows
-        == [XyWindowModel(xy_data_items=[("0", "1"), ("1", "0")], x_range="auto", y_range="auto")]
-    )
+    qtbot.waitUntil(lambda: len(not_none(cast(XyTableStateModel, plot._table._dump_data_model([])).xy_windows)) == 1)
+    model = cast(XyTableStateModel, plot._table._dump_data_model([]))
+    assert not_none(model.xy_windows)[0].xy_data_items == [("0", "1"), ("1", "0")]
 
 
 def test_xy_load(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     model = cast(XyTableStateModel, plot._table._dump_data_model([]))
 
-    model.xy_windows = [XyWindowModel(xy_data_items=[("1", "0")])]
+    model.xy_windows = [XyRefGeoModel(xy_data_items=[("1", "0")])]
     plot._table._load_model(model)
     qtbot.waitUntil(lambda: len(plot._table._xy_plots) == 1)
     assert cast(XyPlotSplitter, plot._table._xy_plots[0])._xy_plots._xys == [("1", "0")]

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -118,13 +118,13 @@ def test_xy_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     xy_plot.add_xy("0", "1")
     xy_plot.add_xy("1", "0")
     qtbot.waitUntil(
-        lambda: cast(XyTableStateModel, plot._table._dump_model([])).xy_windows
+        lambda: cast(XyTableStateModel, plot._table._dump_data_model([])).xy_windows
         == [XyWindowModel(xy_data_items=[("0", "1"), ("1", "0")], x_range="auto", y_range="auto")]
     )
 
 
 def test_xy_load(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    model = cast(XyTableStateModel, plot._table._dump_model([]))
+    model = cast(XyTableStateModel, plot._table._dump_data_model([]))
 
     model.xy_windows = [XyWindowModel(xy_data_items=[("1", "0")])]
     plot._table._load_model(model)

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -15,7 +15,7 @@
 import pytest
 from pytestqt.qtbot import QtBot
 
-from pyqtgraph_scope_plots import XyPlotSplitter
+from pyqtgraph_scope_plots.xy_plot_splitter import XyPlotSplitter
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
 from pyqtgraph_scope_plots.xy_plot_refgeo import RefGeoXyPlotWidget
 
@@ -48,6 +48,6 @@ def test_polyline_fn(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
     qtbot.wait(10)  # wait for rendering to happen
 
 
-def test_table(qtbot: QtBot, splitter: XyPlotSplitter):
+def test_table(qtbot: QtBot, splitter: XyPlotSplitter) -> None:
     splitter._xy_plots.add_ref_geometry_fn("([-1, 1], [-1, -1])")
     qtbot.waitUntil(lambda: splitter._table.item(0, 0).text() == "([-1, 1], [-1, -1])")

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -51,3 +51,8 @@ def test_polyline_fn(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
 def test_table(qtbot: QtBot, splitter: XyPlotSplitter) -> None:
     splitter._xy_plots.add_ref_geometry_fn("([-1, 1], [-1, -1])")
     qtbot.waitUntil(lambda: splitter._table.item(0, 0).text() == "([-1, 1], [-1, -1])")
+
+
+def test_table_err(qtbot: QtBot, splitter: XyPlotSplitter) -> None:
+    splitter._xy_plots.add_ref_geometry_fn("abc")
+    qtbot.waitUntil(lambda: "NameNotDefined" in splitter._table.item(0, 0).text())

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -39,15 +39,11 @@ def splitter(qtbot: QtBot) -> XyPlotSplitter:
 
 
 def test_square_points(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
-    # test that xy creation doesn't error out and follows the user order
-    plot.add_xy("0", "1")
     plot.add_ref_geometry_fn("([-1, 1, 1, -1, -1], [-1, -1, 1, 1, -1])")
     qtbot.wait(10)  # wait for rendering to happen
 
 
 def test_polyline_fn(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
-    # test that xy creation doesn't error out and follows the user order
-    plot.add_xy("0", "1")
     plot.add_ref_geometry_fn("polyline((-1, -1), (1, -1), (1, 1), (-1, 1), (-1, -1))")
     qtbot.wait(10)  # wait for rendering to happen
 

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import pytest
+from pytestqt.qtbot import QtBot
+
+from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
+from pyqtgraph_scope_plots.xy_plot_refgeo import RefGeoXyPlotWidget
+
+
+@pytest.fixture()
+def plot(qtbot: QtBot) -> RefGeoXyPlotWidget:
+    xy_plot = RefGeoXyPlotWidget(MultiPlotWidget())
+    qtbot.addWidget(xy_plot)
+    xy_plot.show()
+    qtbot.waitExposed(xy_plot)
+    return xy_plot
+
+
+def test_square_points(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
+    # test that xy creation doesn't error out and follows the user order
+    plot.add_xy("0", "1")
+    plot.add_ref_geometry_fn("([-1, 1, 1, -1, -1], [-1, -1, 1, 1, -1])")
+    qtbot.wait(10)  # wait for rendering to happen
+
+
+def test_polyline_fn(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
+    # test that xy creation doesn't error out and follows the user order
+    plot.add_xy("0", "1")
+    plot.add_ref_geometry_fn("polyline((-1, -1), (1, -1), (1, 1), (-1, 1), (-1, -1))")
+    qtbot.wait(10)  # wait for rendering to happen

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -39,20 +39,35 @@ def splitter(qtbot: QtBot) -> XyPlotSplitter:
 
 
 def test_square_points(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
-    plot.add_ref_geometry_fn("([-1, 1, 1, -1, -1], [-1, -1, 1, 1, -1])")
+    plot.set_ref_geometry_fn("([-1, 1, 1, -1, -1], [-1, -1, 1, 1, -1])")
     qtbot.wait(10)  # wait for rendering to happen
 
 
 def test_polyline_fn(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
-    plot.add_ref_geometry_fn("polyline((-1, -1), (1, -1), (1, 1), (-1, 1), (-1, -1))")
+    plot.set_ref_geometry_fn("polyline((-1, -1), (1, -1), (1, 1), (-1, 1), (-1, -1))")
     qtbot.wait(10)  # wait for rendering to happen
 
 
 def test_table(qtbot: QtBot, splitter: XyPlotSplitter) -> None:
-    splitter._xy_plots.add_ref_geometry_fn("([-1, 1], [-1, -1])")
-    qtbot.waitUntil(lambda: splitter._table.item(0, 0).text() == "([-1, 1], [-1, -1])")
+    splitter._xy_plots.set_ref_geometry_fn("([-1, 1], [-1, -1])")
+    qtbot.waitUntil(lambda: splitter._table.rowCount() == 1)
+    assert splitter._table.item(0, 0).text() == "([-1, 1], [-1, -1])"
+
+    splitter._xy_plots.set_ref_geometry_fn("([-1, 2], [-1, -1])")  # addition
+    qtbot.waitUntil(lambda: splitter._table.rowCount() == 2)
+    assert splitter._table.item(0, 0).text() == "([-1, 1], [-1, -1])"
+    assert splitter._table.item(1, 0).text() == "([-1, 2], [-1, -1])"
+
+    splitter._xy_plots.set_ref_geometry_fn("([-1, 0], [-1, -1])", 1)  # replacement
+    qtbot.waitUntil(lambda: splitter._table.rowCount() == 2)
+    assert splitter._table.item(0, 0).text() == "([-1, 1], [-1, -1])"
+    assert splitter._table.item(1, 0).text() == "([-1, 0], [-1, -1])"
+
+    splitter._xy_plots.set_ref_geometry_fn("", 0)  # deletion
+    qtbot.waitUntil(lambda: splitter._table.rowCount() == 1)
+    assert splitter._table.item(0, 0).text() == "([-1, 0], [-1, -1])"
 
 
 def test_table_err(qtbot: QtBot, splitter: XyPlotSplitter) -> None:
-    splitter._xy_plots.add_ref_geometry_fn("abc")
+    splitter._xy_plots.set_ref_geometry_fn("abc")
     qtbot.waitUntil(lambda: "NameNotDefined" in splitter._table.item(0, 0).text())

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -15,6 +15,7 @@
 import pytest
 from pytestqt.qtbot import QtBot
 
+from pyqtgraph_scope_plots import XyPlotSplitter
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
 from pyqtgraph_scope_plots.xy_plot_refgeo import RefGeoXyPlotWidget
 
@@ -40,3 +41,13 @@ def test_polyline_fn(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
     plot.add_xy("0", "1")
     plot.add_ref_geometry_fn("polyline((-1, -1), (1, -1), (1, 1), (-1, 1), (-1, -1))")
     qtbot.wait(10)  # wait for rendering to happen
+
+
+def test_table(qtbot: QtBot):
+    splitter = XyPlotSplitter(MultiPlotWidget())
+    qtbot.addWidget(splitter)
+    splitter.show()
+    qtbot.waitExposed(splitter)
+
+    splitter._xy_plots.add_ref_geometry_fn("([-1, 1], [-1, -1])")
+    qtbot.waitUntil(lambda: splitter._table.item(0, 0).text() == "([-1, 1], [-1, -1])")

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -29,6 +29,15 @@ def plot(qtbot: QtBot) -> RefGeoXyPlotWidget:
     return xy_plot
 
 
+@pytest.fixture()
+def splitter(qtbot: QtBot) -> XyPlotSplitter:
+    splitter = XyPlotSplitter(MultiPlotWidget())
+    qtbot.addWidget(splitter)
+    splitter.show()
+    qtbot.waitExposed(splitter)
+    return splitter
+
+
 def test_square_points(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
     # test that xy creation doesn't error out and follows the user order
     plot.add_xy("0", "1")
@@ -43,11 +52,6 @@ def test_polyline_fn(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
     qtbot.wait(10)  # wait for rendering to happen
 
 
-def test_table(qtbot: QtBot):
-    splitter = XyPlotSplitter(MultiPlotWidget())
-    qtbot.addWidget(splitter)
-    splitter.show()
-    qtbot.waitExposed(splitter)
-
+def test_table(qtbot: QtBot, splitter: XyPlotSplitter):
     splitter._xy_plots.add_ref_geometry_fn("([-1, 1], [-1, -1])")
     qtbot.waitUntil(lambda: splitter._table.item(0, 0).text() == "([-1, 1], [-1, -1])")


### PR DESCRIPTION
Add user-specified (as a function -> (xs, ys)) reference geometry, available through the XY table menu. Modeled off data transforms, using simpleeval for the functions, and with the option to modify / delete existing reference geometry.

Some refactoring of the XY plot widget and components:
- Add ref-geo as a mixin into XyPlotWidget, and table-display / controls as mixin into XyPlotTable
- Adds a XY-items changed signal
- Split into 3 files: base XY plot widget + controls table, splitter, and SignalsTable item that provides for XY widget creation
- Add context menu mixin to XyPlotTable

Also a major infrastructural change to support mixin-save-models for XyPlots. Splits the HasSaveLoadConfig into HasSaveLoadConfig (that is structure-agnostic - for the XyPlot window) and HasSaveLoadDataConfig (that imposes the top-level 'data' item, continue to be used for top-level MultiPlotWidget / SignalsTable).
- Also changes the class variable to internal `_MODEL_BASES`
- Instead of returning the data type, that is now obtained by inspection into the top-level model
- Requires a change in signature in write_model / load_model to BaseModel instead of BaseTopModel, which is probably cleaner anyways since most uses need to assert on the model fragment type
- Separate out _dump_model (which takes no arguments) and _dump_data_model (a HasSaveLoadDataConfig which populates the data field)

It is likely the HasSaveLoadConfig infrastructure will continue to evolve, as XyPlots end up doing even more.

Other changes:
- Add sigDataUpdated and sigDataItemsUpdated to MultiPlotWidget and associated tests
- 