### PR TITLE
Data in xy reference geometry

### DIFF
--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -35,6 +35,7 @@ from .search_signals_table import SearchSignalsTable
 from .xy_plot_table import XyTable
 from .xy_plot import XyPlotWidget, XyDragDroppable, XyPlotTable
 from .xy_plot_splitter import XyPlotSplitter
+from .xy_plot_refgeo import RefGeoXyPlotWidget, RefGeoXyPlotTable
 
 from .time_axis import TimeAxisItem
 

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -105,16 +105,20 @@ class SignalsTable(QTableWidget):
 class HasRegionSignalsTable(SignalsTable):
     """A SignalsTable that listens for a region change and provides some utilities"""
 
+    _ROUND_EPSILON_FACTOR = 2e-7
+
     def set_range(self, range: Tuple[float, float]) -> None:
         self._range = range
 
     @classmethod
     def _indices_of_region(
-        cls, xs: npt.NDArray[np.float64], region: Tuple[float, float]
+        cls, ts: npt.NDArray[np.float64], region: Tuple[float, float]
     ) -> Tuple[Optional[int], Optional[int]]:
-        """Given the x points and a region, return the indices of xs containing the region"""
-        low_index = bisect.bisect_left(xs, region[0])  # inclusive
-        high_index = bisect.bisect_right(xs, region[1])  # exclusive
+        """Given sorted ts and a region, return the indices of ts containing the region.
+        Expands the region slightly to account for floating point imprecision"""
+        region = (region[0] - region[0] * cls._ROUND_EPSILON_FACTOR, region[1] + region[1] * cls._ROUND_EPSILON_FACTOR)
+        low_index = bisect.bisect_left(ts, region[0])  # inclusive
+        high_index = bisect.bisect_right(ts, region[1])  # exclusive
         if low_index >= high_index:  # empty set
             return None, None
         else:

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -105,8 +105,6 @@ class SignalsTable(QTableWidget):
 class HasRegionSignalsTable(SignalsTable):
     """A SignalsTable that listens for a region change and provides some utilities"""
 
-    _ROUND_EPSILON_FACTOR = 2e-7
-
     def set_range(self, range: Tuple[float, float]) -> None:
         self._range = range
 
@@ -116,7 +114,9 @@ class HasRegionSignalsTable(SignalsTable):
     ) -> Tuple[Optional[int], Optional[int]]:
         """Given sorted ts and a region, return the indices of ts containing the region.
         Expands the region slightly to account for floating point imprecision"""
-        region = (region[0] - region[0] * cls._ROUND_EPSILON_FACTOR, region[1] + region[1] * cls._ROUND_EPSILON_FACTOR)
+        ROUNDING_FACTOR = 2e-7
+
+        region = (region[0] - region[0] * ROUNDING_FACTOR, region[1] + region[1] * ROUNDING_FACTOR)
         low_index = bisect.bisect_left(ts, region[0])  # inclusive
         high_index = bisect.bisect_right(ts, region[1])  # exclusive
         if low_index >= high_index:  # empty set

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -94,6 +94,13 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
             self._update()
         self.sigXyDataItemsChanged.emit()
 
+    def _get_region(self) -> Tuple[float, float]:
+        """Gets the currently selected region from the plot, or (-inf, inf) by default."""
+        if isinstance(self._plots, LinkedMultiPlotWidget) and isinstance(self._plots._last_region, tuple):
+            return self._plots._last_region
+        else:
+            return (-float("inf"), float("inf"))
+
     @staticmethod
     def _get_correlated_indices(
         x_ts: npt.NDArray[np.float64], y_ts: npt.NDArray[np.float64], start: float, end: float
@@ -117,10 +124,7 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
         for data_item in self.listDataItems():  # clear existing
             self.removeItem(data_item)
 
-        region = (-float("inf"), float("inf"))
-        if isinstance(self._plots, LinkedMultiPlotWidget) and isinstance(self._plots._last_region, tuple):
-            region = self._plots._last_region  # get region from plot
-
+        region = self._get_region()
         data = self._plots._data
         for x_name, y_name in self._xys:
             x_ts, x_ys = data.get(x_name, (None, None))

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -52,12 +52,10 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
     _FADE_SEGMENTS = 16
 
     sigXyDataItemsChanged = Signal()
-    sigDataChanged = Signal()
 
     def __init__(self, plots: MultiPlotWidget):
         super().__init__(plots)
         self._xys: List[Tuple[str, str]] = []
-        self._data: Dict[str, Sequence[float]] = {}  # post-region filtering, aligned
 
         plots.sigDataUpdated.connect(self._update)
         if isinstance(self._plots, LinkedMultiPlotWidget):

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -95,12 +95,6 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
         self.sigXyDataItemsChanged.emit()
 
     @staticmethod
-    def _get_region_data_indices(
-        data: List[npt.NDArray[np.float64]], region: Tuple[float, float]
-    ) -> List[Tuple[int, int]]:
-        pass
-
-    @staticmethod
     def _get_correlated_indices(
         x_ts: npt.NDArray[np.float64], y_ts: npt.NDArray[np.float64], start: float, end: float
     ) -> Optional[Tuple[Tuple[int, int], Tuple[int, int]]]:

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -50,7 +50,6 @@ class BaseXyPlot(HasSaveLoadConfig):
 
 class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
     _FADE_SEGMENTS = 16
-    _ROUND_EPSILON_FACTOR = 2e-7
 
     sigXyDataItemsChanged = Signal()
     sigDataChanged = Signal()
@@ -98,6 +97,12 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
         self.sigXyDataItemsChanged.emit()
 
     @staticmethod
+    def _get_region_data_indices(
+        data: List[npt.NDArray[np.float64]], region: Tuple[float, float]
+    ) -> List[Tuple[int, int]]:
+        pass
+
+    @staticmethod
     def _get_correlated_indices(
         x_ts: npt.NDArray[np.float64], y_ts: npt.NDArray[np.float64], start: float, end: float
     ) -> Optional[Tuple[Tuple[int, int], Tuple[int, int]]]:
@@ -108,17 +113,6 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
         if xt_lo is None or xt_hi is None or yt_lo is None or yt_hi is None or xt_hi - xt_lo < 2:
             return None
 
-        # correct for floating point imprecision in indices
-        if (xt_hi - xt_lo) == (yt_hi - yt_lo) + 1:  # delete an extra x-point
-            if abs(y_ts[yt_lo] - x_ts[xt_lo]) > abs(y_ts[yt_hi - 1] - x_ts[xt_hi - 1]):  # larger delta on low point
-                xt_lo = xt_lo + 1
-            else:
-                xt_hi = xt_hi - 1
-        elif (xt_hi - xt_lo) + 1 == (yt_hi - yt_lo):  # delete an extra y-point
-            if abs(y_ts[yt_lo] - x_ts[xt_lo]) > abs(y_ts[yt_hi - 1] - x_ts[xt_hi - 1]):  # larger delta on low point
-                yt_lo = yt_lo + 1
-            else:
-                yt_hi = yt_hi - 1
         if (xt_hi - xt_lo) != (yt_hi - yt_lo):
             return None
         x_indices = x_ts[xt_lo:xt_hi]

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -49,16 +49,16 @@ class BaseXyPlot(HasSaveLoadConfig):
 
 
 class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
-    FADE_SEGMENTS = 16
+    _FADE_SEGMENTS = 16
+    _ROUND_EPSILON_FACTOR = 2e-7
 
     sigXyDataItemsChanged = Signal()
+    sigDataChanged = Signal()
 
     def __init__(self, plots: MultiPlotWidget):
         super().__init__(plots)
         self._xys: List[Tuple[str, str]] = []
-
-        self._drag_overlays: List[DragTargetOverlay] = []
-        self.setAcceptDrops(True)
+        self._data: Dict[str, Sequence[float]] = {}  # post-region filtering, aligned
 
         plots.sigDataUpdated.connect(self._update)
         if isinstance(self._plots, LinkedMultiPlotWidget):
@@ -154,7 +154,7 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
             # PyQtGraph doesn't support native fade colors, so approximate with multiple segments
             y_color, _ = self._plots._data_items.get(y_name, (QColor("white"), None))
             fade_segments = min(
-                self.FADE_SEGMENTS, xt_hi - xt_lo
+                self._FADE_SEGMENTS, xt_hi - xt_lo
             )  # keep track of the x time indices, apply offset for y time indices
             last_segment_end = xt_lo
             for i in range(fade_segments):

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -12,8 +12,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 from functools import partial
-from typing import Any, List, Tuple, Dict, Sequence, Callable, Optional
+from typing import Any, List, Tuple, Dict, Sequence, Callable, Optional, Mapping
 
+import numpy as np
+import numpy.typing as npt
 import simpleeval
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QInputDialog, QLineEdit

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -22,7 +22,7 @@ from PySide6.QtWidgets import QMenu, QInputDialog, QLineEdit
 import pyqtgraph as pg
 from pydantic import BaseModel
 
-from .signals_table import SignalsTable
+from .signals_table import SignalsTable, HasRegionSignalsTable
 from .xy_plot import XyPlotWidget, XyPlotTable, ContextMenuXyPlotTable, XyWindowModel
 
 
@@ -97,12 +97,24 @@ class RefGeoXyPlotWidget(XyPlotWidget):
     def _update(self) -> None:
         super()._update()  # data items drawn here
 
+        region = self._get_region()
+
+        def get_data_region(ts: npt.NDArray[np.float64], ys: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+            """Given ts and xs of a data item, return ys bounded to the input region."""
+            ts_lo, ts_hi = HasRegionSignalsTable._indices_of_region(ts, region)
+            if ts_lo is None or ts_hi is None:
+                return np.array([])
+            else:
+                return ys[ts_lo:ts_hi]
+
+        filtered_data = {name: get_data_region(ts, ys) for name, (ts, ys) in self._plots._data.items()}
+
         # draw reference geometry
         last_refgeo_err = any([err is not None for err in self._refgeo_errs])  # store last to emit on failing -> ok
         self._refgeo_errs = []
         for refgeo_expr, refgeo_parsed in self._refgeo_fns:
             self._simpleeval.names = {
-                # "data": other_data_dict,  # TODO support aligned data
+                "data": filtered_data,
             }
             try:
                 xs, ys = self._simpleeval.eval(refgeo_expr, refgeo_parsed)
@@ -164,7 +176,7 @@ class RefGeoXyPlotTable(ContextMenuXyPlotTable, XyPlotTable):
                 self,
                 "Add reference geometry",
                 "Function for reference geometry, as (xs, ys), for example '([0, 1], [0, 1])' for a diagonal line. \n"
-                # "Use 'data['...']' or 'data.get('...') to access the data sequence (bounded to the selected region) by name. \n"  # TODO
+                "Use 'data['...']' to access the data sequence, bounded to the selected region, by name. \n"
                 "These helper functions are available: \n" + fn_help_str + err_msg,
                 QLineEdit.EchoMode.Normal,
                 text,

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -14,7 +14,7 @@
 from typing import Type
 
 from PySide6 import QtGui
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QSplitter
 from pydantic import BaseModel
 

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -12,9 +12,12 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 from typing import cast
+from unittest import mock
 
 import pytest
+from PySide6.QtGui import QColor
 from pytestqt.qtbot import QtBot
+import pyqtgraph as pg
 
 from pyqtgraph_scope_plots.xy_plot_splitter import XyPlotSplitter
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
@@ -40,13 +43,40 @@ def splitter(qtbot: QtBot) -> XyPlotSplitter:
 
 
 def test_square_points(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
-    plot.set_ref_geometry_fn("([-1, 1, 1, -1, -1], [-1, -1, 1, 1, -1])")
-    qtbot.wait(10)  # wait for rendering to happen
+    with mock.patch.object(plot, "addItem") as mock_add_item:
+        plot.set_ref_geometry_fn("([-1, 1, 1, -1, -1], [-1, -1, 1, 1, -1])")
+        mock_add_item.assert_called_once()
+        curve = cast(pg.PlotCurveItem, mock_add_item.call_args[0][0])
+        assert list(curve.xData) == [-1, 1, 1, -1, -1]
+        assert list(curve.yData) == [-1, -1, 1, 1, -1]
 
 
 def test_polyline_fn(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
-    plot.set_ref_geometry_fn("polyline((-1, -1), (1, -1), (1, 1), (-1, 1), (-1, -1))")
-    qtbot.wait(10)  # wait for rendering to happen
+    with mock.patch.object(plot, "addItem") as mock_add_item:
+        plot.set_ref_geometry_fn("polyline((-1, -1), (1, -1), (1, 1), (-1, 1), (-1, -1))")
+        mock_add_item.assert_called_once()
+        curve = cast(pg.PlotCurveItem, mock_add_item.call_args[0][0])
+        assert list(curve.xData) == [-1, 1, 1, -1, -1]
+        assert list(curve.yData) == [-1, -1, 1, 1, -1]
+
+
+def test_data(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
+    plot._plots.show_data_items([("x", QColor("white"), MultiPlotWidget.PlotType.DEFAULT)])
+    plot._plots.set_data({"x": ([0, 1, 2], [0, 1, 2])})
+
+    with mock.patch.object(plot, "addItem") as mock_add_item:
+        plot.set_ref_geometry_fn("polyline((-1, data['x'][-1]), (1, data['x'][-1]))")
+        mock_add_item.assert_called_once()
+        curve = cast(pg.PlotCurveItem, mock_add_item.call_args[0][0])
+        assert list(curve.xData) == [-1, 1]
+        assert list(curve.yData) == [2, 2]
+
+    with mock.patch.object(plot, "addItem") as mock_add_item:
+        plot.set_ref_geometry_fn("polyline((-1, data['x'][-1]), (1, data['x'][0]))", 0)
+        mock_add_item.assert_called_once()
+        curve = cast(pg.PlotCurveItem, mock_add_item.call_args[0][0])
+        assert list(curve.xData) == [-1, 1]
+        assert list(curve.yData) == [2, 0]
 
 
 def test_table(qtbot: QtBot, splitter: XyPlotSplitter) -> None:

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -85,11 +85,11 @@ def test_data_region(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
     cast(LinkedMultiPlotWidget, plot._plots)._on_region_change(None, (0, 1))
 
     with mock.patch.object(plot, "addItem") as mock_add_item:
-        plot.set_ref_geometry_fn("polyline((-1, data['x'][0]), (1, data['x'][-1]))")
+        plot.set_ref_geometry_fn("polyline((data['x'][0], -1), (data['x'][-1], 1))")
         mock_add_item.assert_called_once()
         curve = cast(pg.PlotCurveItem, mock_add_item.call_args[0][0])
-        assert list(curve.xData) == [-1, 1]
-        assert list(curve.yData) == [0, 1]
+        assert list(curve.xData) == [0, 1]
+        assert list(curve.yData) == [-1, 1]
 
 
 def test_table(qtbot: QtBot, splitter: XyPlotSplitter) -> None:


### PR DESCRIPTION
Add data over the selected region to the XY reference geometry expressions.

Modifies the XY data-region selection by expanding the range to account for FP inaccuracy and replacing the odd off-by-one logic. Updates XY tests to actually check created geometry.

Also cleans up some leftover unused drag'n'drop logic