### PR TITLE
Restructure signals table to be a control into the plots

### DIFF
--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -22,10 +22,8 @@ from .interactivity_mixins import (
 )
 from .enum_waveform_plotitem import EnumWaveformPlot
 from .plots_table_widget import PlotsTableWidget
-from .signals_table import (
-    DeleteableSignalsTable,
-    DraggableSignalsTable,
-)
+from .multi_plot_widget import MultiPlotWidget, LinkedMultiPlotWidget
+from .signals_table import DeleteableSignalsTable, DraggableSignalsTable
 from .stats_signals_table import StatsSignalsTable
 from .color_signals_table import ColorPickerPlotWidget, ColorPickerSignalsTable
 from .timeshift_signals_table import TimeshiftPlotWidget, TimeshiftSignalsTable

--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -24,10 +24,10 @@ from .enum_waveform_plotitem import EnumWaveformPlot
 from .plots_table_widget import PlotsTableWidget
 from .signals_table import (
     DeleteableSignalsTable,
-    ColorPickerSignalsTable,
     DraggableSignalsTable,
 )
 from .stats_signals_table import StatsSignalsTable
+from .color_signals_table import ColorPickerPlotWidget, ColorPickerSignalsTable
 from .timeshift_signals_table import TimeshiftPlotWidget, TimeshiftSignalsTable
 from .transforms_signal_table import TransformsPlotWidget, TransformsSignalsTable
 from .search_signals_table import SearchSignalsTable

--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -29,7 +29,7 @@ from .signals_table import (
 )
 from .stats_signals_table import StatsSignalsTable
 from .timeshift_signals_table import TimeshiftSignalsTable
-from .transforms_signal_table import TransformsSignalsTable
+from .transforms_signal_table import TransformsPlotWidget, TransformsSignalsTable
 from .search_signals_table import SearchSignalsTable
 from .xy_plot_table import XyTable
 from .xy_plot import XyPlotWidget, XyDragDroppable, XyPlotTable

--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -24,11 +24,10 @@ from .enum_waveform_plotitem import EnumWaveformPlot
 from .plots_table_widget import PlotsTableWidget
 from .signals_table import (
     DeleteableSignalsTable,
-    HasDataSignalsTable,
-    StatsSignalsTable,
     ColorPickerSignalsTable,
     DraggableSignalsTable,
 )
+from .stats_signals_table import StatsSignalsTable
 from .timeshift_signals_table import TimeshiftSignalsTable
 from .transforms_signal_table import TransformsSignalsTable
 from .search_signals_table import SearchSignalsTable

--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -28,7 +28,7 @@ from .signals_table import (
     DraggableSignalsTable,
 )
 from .stats_signals_table import StatsSignalsTable
-from .timeshift_signals_table import TimeshiftSignalsTable
+from .timeshift_signals_table import TimeshiftPlotWidget, TimeshiftSignalsTable
 from .transforms_signal_table import TransformsPlotWidget, TransformsSignalsTable
 from .search_signals_table import SearchSignalsTable
 from .xy_plot_table import XyTable

--- a/pyqtgraph_scope_plots/animation_plot_table_widget.py
+++ b/pyqtgraph_scope_plots/animation_plot_table_widget.py
@@ -18,6 +18,7 @@ from PySide6 import QtGui
 from PySide6.QtWidgets import QInputDialog, QFileDialog, QWidget
 from PIL import Image
 
+from .multi_plot_widget import LinkedMultiPlotWidget
 from .xy_plot_table import XyTable
 from .plots_table_widget import PlotsTableWidget
 
@@ -25,12 +26,16 @@ from .plots_table_widget import PlotsTableWidget
 class AnimationPlotsTableWidget(PlotsTableWidget):
     """A PlotTableWidget that provides a function for generating an animation from the plot windows.
     This function handles the UI flow for generating an animation, but does not provide the controls
-    to initiate this flow (which is left up to the subclass to implement)"""
+    to initiate this flow (which is left up to the subclass to implement).
+
+    Plots must be LinkedMultiPlotWidget"""
 
     FRAMES_PER_SEGMENT = 8  # TODO these should be user-configurable
     MS_PER_FRAME = 50
 
     def _start_animation_ui_flow(self, default_filename: str = "") -> None:
+        assert isinstance(self._plots, LinkedMultiPlotWidget)
+
         region_percentage, ok = QInputDialog().getDouble(
             self, "Animation", "Region percentage per frame", 10, minValue=0, maxValue=100
         )

--- a/pyqtgraph_scope_plots/animation_plot_table_widget.py
+++ b/pyqtgraph_scope_plots/animation_plot_table_widget.py
@@ -41,7 +41,7 @@ class AnimationPlotsTableWidget(PlotsTableWidget):
             full_region = self._plots._last_region
             restore_full_region = True
         else:
-            all_xs = [data[0] for data in self._transformed_data.values()]
+            all_xs = [data[0] for data in self._plots._data.values()]
             min_xs = [min(data) for data in all_xs if len(data)]
             max_xs = [max(data) for data in all_xs if len(data)]
             assert min_xs or max_xs, "no data to determine full region"

--- a/pyqtgraph_scope_plots/color_signals_table.py
+++ b/pyqtgraph_scope_plots/color_signals_table.py
@@ -78,8 +78,6 @@ class ColorPickerSignalsTable(ContextMenuSignalsTable):
     This gets sent as a signal, and an upper must handle plumbing the colors through.
     """
 
-    _DATA_MODEL_BASES = [ColorPickerDataStateModel]
-
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 

--- a/pyqtgraph_scope_plots/color_signals_table.py
+++ b/pyqtgraph_scope_plots/color_signals_table.py
@@ -28,7 +28,6 @@ class ColorPickerDataStateModel(DataTopModel):
 
 
 class ColorPickerPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
-
     _DATA_MODEL_BASES = [ColorPickerDataStateModel]
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/pyqtgraph_scope_plots/color_signals_table.py
+++ b/pyqtgraph_scope_plots/color_signals_table.py
@@ -28,6 +28,9 @@ class ColorPickerDataStateModel(DataTopModel):
 
 
 class ColorPickerPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
+
+    _DATA_MODEL_BASES = [ColorPickerDataStateModel]
+
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self._colors: Dict[str, QColor] = {}  # only for save state

--- a/pyqtgraph_scope_plots/color_signals_table.py
+++ b/pyqtgraph_scope_plots/color_signals_table.py
@@ -70,8 +70,8 @@ class ColorPickerPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
     def set_colors(self, data_names: List[str], color: QColor, update: bool = True) -> None:
         for data_name in data_names:
             self._colors[data_name] = color
+        self._update_data_item_colors()
         if update:
-            self._update_data_item_colors()
             self._update_plots()
             self.sigDataItemsUpdated.emit()
 

--- a/pyqtgraph_scope_plots/color_signals_table.py
+++ b/pyqtgraph_scope_plots/color_signals_table.py
@@ -50,6 +50,8 @@ class ColorPickerPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
                 self.set_colors([data_name], QColor(data_model.color), update=False)
 
     def _update_data_item_colors(self) -> None:
+        # TODO: not needed right now, but a better architecture might be to store the raw data items
+        # and have a _transform_data_items function
         new_data_items = {}
         for data_item_name, (color, plot_type) in self._data_items.items():
             changed_color = self._colors.get(data_item_name, None)

--- a/pyqtgraph_scope_plots/color_signals_table.py
+++ b/pyqtgraph_scope_plots/color_signals_table.py
@@ -1,0 +1,96 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from typing import Dict, Any, Optional, List
+
+from PySide6.QtGui import QColor, QAction
+from PySide6.QtWidgets import QMenu, QColorDialog
+from pydantic import BaseModel
+
+from .multi_plot_widget import MultiPlotWidget
+from .save_restore_model import BaseTopModel, DataTopModel, HasSaveLoadDataConfig
+from .signals_table import ContextMenuSignalsTable
+
+
+class ColorPickerDataStateModel(DataTopModel):
+    color: Optional[str] = None  # QColor name, e.g., '#ffea70' or 'red'
+
+
+class ColorPickerPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._colors: Dict[str, QColor] = {}  # only for save state
+
+    def _write_model(self, model: BaseModel) -> None:
+        assert isinstance(model, BaseTopModel)
+        super()._write_model(model)
+        for data_name, data_model in model.data.items():
+            assert isinstance(data_model, ColorPickerDataStateModel)
+            color = self._colors.get(data_name, None)
+            if color is not None:
+                data_model.color = color.name()
+
+    def _load_model(self, model: BaseModel) -> None:
+        assert isinstance(model, BaseTopModel)
+        super()._load_model(model)
+        for data_name, data_model in model.data.items():
+            assert isinstance(data_model, ColorPickerDataStateModel)
+            if data_model.color is not None:
+                self.set_colors([data_name], QColor(data_model.color), update=False)
+
+    def _update_data_item_colors(self) -> None:
+        new_data_items = {}
+        for data_item_name, (color, plot_type) in self._data_items.items():
+            changed_color = self._colors.get(data_item_name, None)
+            if changed_color is not None:
+                color = changed_color
+            new_data_items[data_item_name] = (color, plot_type)
+        self._data_items = new_data_items
+
+    def show_data_items(self, *args: Any, **kwargs: Any) -> None:
+        super().show_data_items(*args, **kwargs)
+        self._update_data_item_colors()
+
+    def set_colors(self, data_names: List[str], color: QColor, update: bool = True) -> None:
+        for data_name in data_names:
+            self._colors[data_name] = color
+        if update:
+            self._update_data_item_colors()
+            self._update_plots()
+            self.sigDataItemsUpdated.emit()
+
+
+class ColorPickerSignalsTable(ContextMenuSignalsTable):
+    """Mixin into SignalsTable that adds a context menu item for the user to change the color.
+    This gets sent as a signal, and an upper must handle plumbing the colors through.
+    """
+
+    _DATA_MODEL_BASES = [ColorPickerDataStateModel]
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
+        self._set_color_action = QAction("Set Color", self)
+        self._set_color_action.triggered.connect(self._on_set_color)
+
+    def _populate_context_menu(self, menu: QMenu) -> None:
+        super()._populate_context_menu(menu)
+        menu.addAction(self._set_color_action)
+
+    def _on_set_color(self) -> None:
+        assert isinstance(self._plots, ColorPickerPlotWidget)
+        data_names = list(self._data_items.keys())
+        selected_data_names = [data_names[item.row()] for item in self.selectedItems()]
+        color = QColorDialog.getColor()
+        self._plots.set_colors(selected_data_names, color)

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -139,6 +139,9 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
 
         self._table: CsvLoaderPlotsTableWidget.SignalsTable
 
+        # since this can load multiple CSVs simultaneously, store the data here
+        self._data_items: Dict[str, MultiPlotWidget.PlotType] = {}  # col header -> plot type IF NOT Default
+        self._data: Dict[str, Tuple[np.typing.ArrayLike, np.typing.ArrayLike]] = {}  # col header -> xs, ys
         self._csv_data_items: Dict[str, Set[str]] = {}  # csv path -> data name
         self._csv_time: Dict[str, float] = {}  # csv path -> load time
         self._watch_timer = QTimer()
@@ -315,9 +318,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         data_dict: Dict[str, Tuple[np.typing.ArrayLike, np.typing.ArrayLike]] = {}  # col header -> xs, ys
         csv_data_items_dict: Dict[str, Set[str]] = {}
         if append:
-            data_type_dict.update(
-                {data_name: data_type for data_name, (data_color, data_type) in self._data_items.items()}
-            )
+            data_type_dict.update(self._data_items)
             data_dict.update(self._data)
             csv_data_items_dict.update(self._csv_data_items)
 

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -166,16 +166,17 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         self._table._load_model(model)
         self._plots._load_model(model)
 
-    def _transform_data(
-        self,
-        data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
-    ) -> Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]]:
-        # apply time-shift before function transform
-        transformed_data = {}
-        for data_name in data.keys():
-            transformed = self._table.apply_timeshifts(data_name, data)
-            transformed_data[data_name] = transformed, data[data_name][1]
-        return super()._transform_data(transformed_data)
+    # TODO apply timeshift in plot/signaltable
+    # def _transform_data(
+    #     self,
+    #     data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
+    # ) -> Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]]:
+    #     # apply time-shift before function transform
+    #     transformed_data = {}
+    #     for data_name in data.keys():
+    #         transformed = self._table.apply_timeshifts(data_name, data)
+    #         transformed_data[data_name] = transformed, data[data_name][1]
+    #     return super()._transform_data(transformed_data)
 
     def _on_color_changed(self, items: List[Tuple[str, QColor]]) -> None:
         updated_data_items = self._data_items.copy()

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -193,23 +193,24 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         if not data_names:
             return
 
-        # try to find a drag point that is near the center of the view window, and preferably at a data point
-        view_left, view_right = self._plots.view_x_range()
-        view_center = (view_left + view_right) / 2
-        data_x, data_y = self._transformed_data.get(data_names[0], (np.array([]), np.array([])))
-        index = bisect.bisect_left(data_x, view_center)
-        if index >= len(data_x):  # snap to closest point
-            index = len(data_x) - 1
-        elif index < 0:
-            index = 0
-        if len(data_x) and data_x[index] >= view_left and data_x[index] <= view_right:  # point in view
-            handle_pos = float(data_x[index])  # cast from numpy float
-        else:  # no points in view
-            handle_pos = view_center
-
-        self._drag_handle_data = data_names
-        self._drag_handle_offset = handle_pos - initial_timeshift
-        self._plots.create_drag_cursor(handle_pos)
+        # TODO migrate
+        # # try to find a drag point that is near the center of the view window, and preferably at a data point
+        # view_left, view_right = self._plots.view_x_range()
+        # view_center = (view_left + view_right) / 2
+        # data_x, data_y = self._transformed_data.get(data_names[0], (np.array([]), np.array([])))
+        # index = bisect.bisect_left(data_x, view_center)
+        # if index >= len(data_x):  # snap to closest point
+        #     index = len(data_x) - 1
+        # elif index < 0:
+        #     index = 0
+        # if len(data_x) and data_x[index] >= view_left and data_x[index] <= view_right:  # point in view
+        #     handle_pos = float(data_x[index])  # cast from numpy float
+        # else:  # no points in view
+        #     handle_pos = view_center
+        #
+        # self._drag_handle_data = data_names
+        # self._drag_handle_offset = handle_pos - initial_timeshift
+        # self._plots.create_drag_cursor(handle_pos)
 
     def _on_timeshift_change(self, data_names: List[str]) -> None:
         self._set_data(self._data)  # TODO minimal changes in the future

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -45,7 +45,8 @@ from ..multi_plot_widget import MultiPlotWidget
 from ..plots_table_widget import PlotsTableWidget
 from ..save_restore_model import BaseTopModel, HasSaveLoadDataConfig
 from ..search_signals_table import SearchSignalsTable
-from ..signals_table import ColorPickerSignalsTable, StatsSignalsTable
+from ..signals_table import ColorPickerSignalsTable
+from ..stats_signals_table import StatsSignalsTable
 from ..time_axis import TimeAxisItem
 from ..timeshift_signals_table import TimeshiftSignalsTable
 from ..transforms_signal_table import TransformsSignalsTable

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -343,11 +343,11 @@ class MultiPlotWidget(HasSaveLoadDataConfig, QSplitter):
         """Sets the data to be plotted as data name -> (xs, ys). Data names must have been previously set with
         set_data_items, missing items will log an error."""
         self._raw_data = {name: (self._to_array(xs), self._to_array(ys)) for name, (xs, ys) in data.items()}
-        self._data = self._transform_data(self._raw_data)
         self._update_plots()
         self.sigDataUpdated.emit()
 
     def _update_plots(self) -> None:
+        self._data = self._transform_data(self._raw_data)
         for plot_item, data_names in self._plot_item_data.items():
             if isinstance(plot_item, EnumWaveformPlot):  # TODO: enum plots have a different API, this should be unified
                 data_name = data_names[0]

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -14,7 +14,7 @@
 
 import csv
 from io import StringIO
-from typing import Tuple, List, Any, Mapping, Union, Optional, TextIO
+from typing import Tuple, List, Any, Mapping, Union, Optional, TextIO, Type
 
 import numpy as np
 import numpy.typing as npt
@@ -26,24 +26,27 @@ from .multi_plot_widget import (
     DroppableMultiPlotWidget,
     LinkedMultiPlotWidget,
 )
-from .signals_table import DraggableSignalsTable
+from .signals_table import DraggableSignalsTable, SignalsTable
 
 
 class PlotsTableWidget(QSplitter):
-    class PlotsTableMultiPlots(DroppableMultiPlotWidget, LinkedMultiPlotWidget):
+    class Plots(DroppableMultiPlotWidget, LinkedMultiPlotWidget):
         """MultiPlotWidget used in PlotsTableWidget with required mixins."""
 
-    class PlotsTableSignalsTable(DraggableSignalsTable):
+    class SignalsTable(DraggableSignalsTable):
         """SignalsTable used in PlotsTableWidget with required mixins."""
 
-    def _make_plots(self) -> PlotsTableMultiPlots:
-        """Returns the plots widget. Optionally override to use a different plots widget."""
-        return self.PlotsTableMultiPlots()
+    _PLOT_TYPE: Type[MultiPlotWidget] = Plots
+    _TABLE_TYPE: Type[SignalsTable] = SignalsTable
 
-    def _make_table(self) -> PlotsTableSignalsTable:
+    def _make_plots(self) -> Plots:
+        """Returns the plots widget. Optionally override to use a different plots widget."""
+        return self._PLOT_TYPE()
+
+    def _make_table(self) -> SignalsTable:
         """Returns the signals table widget. Optionally override to use a different signals widget.
         Plots are created first, and this may reference plots."""
-        return self.PlotsTableSignalsTable(self._plots)
+        return self._TABLE_TYPE(self._plots)
 
     def _make_controls(self) -> Optional[QWidget]:
         """Returns the control panel widget. Optional, defaults to empty."""

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -14,7 +14,7 @@
 
 import csv
 from io import StringIO
-from typing import Dict, Tuple, List, Any, Mapping, Union, Optional, TextIO
+from typing import Tuple, List, Any, Mapping, Union, Optional, TextIO
 
 import numpy as np
 import numpy.typing as npt
@@ -27,16 +27,13 @@ from .multi_plot_widget import (
     LinkedMultiPlotWidget,
 )
 from .signals_table import DraggableSignalsTable
-from .stats_signals_table import StatsSignalsTable
-from .transforms_signal_table import TransformsSignalsTable, TransformsPlotWidget
-from .xy_plot_table import XyTable
 
 
 class PlotsTableWidget(QSplitter):
-    class PlotsTableMultiPlots(TransformsPlotWidget, DroppableMultiPlotWidget, LinkedMultiPlotWidget):
+    class PlotsTableMultiPlots(DroppableMultiPlotWidget, LinkedMultiPlotWidget):
         """MultiPlotWidget used in PlotsTableWidget with required mixins."""
 
-    class PlotsTableSignalsTable(XyTable, DraggableSignalsTable, TransformsSignalsTable, StatsSignalsTable):
+    class PlotsTableSignalsTable(DraggableSignalsTable):
         """SignalsTable used in PlotsTableWidget with required mixins."""
 
     def _make_plots(self) -> PlotsTableMultiPlots:

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -82,14 +82,6 @@ class PlotsTableWidget(QSplitter):
         self._plots.show_data_items(new_data_items, no_create=len(new_data_items) > 8)
         self._table.set_data_items([(data_name, color) for data_name, color, _ in new_data_items])
 
-    def _to_array(self, x: npt.ArrayLike) -> npt.NDArray[np.float64]:
-        if isinstance(x, np.ndarray) and x.flags.writeable == False:
-            return x
-        else:
-            arr = np.array(x)
-            arr.flags.writeable = False
-            return arr
-
     def _transform_data(
         self,
         data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -36,7 +36,7 @@ class PlotsTableWidget(QSplitter):
     class SignalsTable(DraggableSignalsTable):
         """SignalsTable used in PlotsTableWidget with required mixins."""
 
-    _PLOT_TYPE: Type[MultiPlotWidget] = Plots
+    _PLOT_TYPE: Type[Plots] = Plots
     _TABLE_TYPE: Type[SignalsTable] = SignalsTable
 
     def _make_plots(self) -> Plots:

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -26,7 +26,8 @@ from .multi_plot_widget import (
     DroppableMultiPlotWidget,
     LinkedMultiPlotWidget,
 )
-from .signals_table import StatsSignalsTable, DraggableSignalsTable
+from .signals_table import DraggableSignalsTable
+from .stats_signals_table import StatsSignalsTable
 from .transforms_signal_table import TransformsSignalsTable
 from .xy_plot_table import XyTable
 

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -28,12 +28,12 @@ from .multi_plot_widget import (
 )
 from .signals_table import DraggableSignalsTable
 from .stats_signals_table import StatsSignalsTable
-from .transforms_signal_table import TransformsSignalsTable
+from .transforms_signal_table import TransformsSignalsTable, TransformsPlotWidget
 from .xy_plot_table import XyTable
 
 
 class PlotsTableWidget(QSplitter):
-    class PlotsTableMultiPlots(DroppableMultiPlotWidget, LinkedMultiPlotWidget):
+    class PlotsTableMultiPlots(TransformsPlotWidget, DroppableMultiPlotWidget, LinkedMultiPlotWidget):
         """MultiPlotWidget used in PlotsTableWidget with required mixins."""
 
     class PlotsTableSignalsTable(XyTable, DraggableSignalsTable, TransformsSignalsTable, StatsSignalsTable):

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -36,10 +36,10 @@ class PlotsTableWidget(QSplitter):
     class SignalsTable(DraggableSignalsTable):
         """SignalsTable used in PlotsTableWidget with required mixins."""
 
-    _PLOT_TYPE: Type[Plots] = Plots
+    _PLOT_TYPE: Type[LinkedMultiPlotWidget] = Plots
     _TABLE_TYPE: Type[SignalsTable] = SignalsTable
 
-    def _make_plots(self) -> Plots:
+    def _make_plots(self) -> LinkedMultiPlotWidget:
         """Returns the plots widget. Optionally override to use a different plots widget."""
         return self._PLOT_TYPE()
 

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -71,14 +71,10 @@ class PlotsTableWidget(QSplitter):
         else:
             self.addWidget(self._table)
 
-        self._data_items: Dict[str, Tuple[QColor, "MultiPlotWidget.PlotType"]] = {}
-        self._data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = {}
-
     def _set_data_items(
         self,
         new_data_items: List[Tuple[str, QColor, "MultiPlotWidget.PlotType"]],
     ) -> None:
-        self._data_items = {name: (color, plot_type) for name, color, plot_type in new_data_items}
         self._plots.show_data_items(new_data_items, no_create=len(new_data_items) > 8)
 
     def _set_data(
@@ -89,10 +85,10 @@ class PlotsTableWidget(QSplitter):
 
     def _write_csv(self, fileio: Union[TextIO, StringIO]) -> None:
         writer = csv.writer(fileio)
-        writer.writerow(["# time"] + [name for name, _ in self._data.items()])
+        writer.writerow(["# time"] + [name for name, _ in self._plots._data.items()])
 
-        indices = [0] * len(self._data.items())  # indices to examine on current iteration, in self._data order
-        ordered_data_items = list(self._data.values())
+        indices = [0] * len(self._plots._data.items())  # indices to examine on current iteration, in self._data order
+        ordered_data_items = list(self._plots._data.values())
         while True:  # iterate each row
             xs_at_index = [
                 ordered_data_items[data_index][0][point_index]
@@ -114,8 +110,6 @@ class PlotsTableWidget(QSplitter):
 
     def _save_csv_dialog(self) -> None:
         """Utility function to open a dialog to export the current data to a CSV with a shared x-axis column."""
-        if self._data is None:
-            return
         filename, filter = QFileDialog.getSaveFileName(self, f"Save Data", "", "CSV (*.csv)")
         if not filename:
             return

--- a/pyqtgraph_scope_plots/plots_table_widget.py
+++ b/pyqtgraph_scope_plots/plots_table_widget.py
@@ -26,7 +26,8 @@ from .multi_plot_widget import (
     DroppableMultiPlotWidget,
     LinkedMultiPlotWidget,
 )
-from .signals_table import DraggableSignalsTable, SignalsTable
+from .signals_table import DraggableSignalsTable
+from .signals_table import SignalsTable as OriginalSignalsTable
 
 
 class PlotsTableWidget(QSplitter):
@@ -36,14 +37,14 @@ class PlotsTableWidget(QSplitter):
     class SignalsTable(DraggableSignalsTable):
         """SignalsTable used in PlotsTableWidget with required mixins."""
 
-    _PLOT_TYPE: Type[LinkedMultiPlotWidget] = Plots
-    _TABLE_TYPE: Type[SignalsTable] = SignalsTable
+    _PLOT_TYPE: Type[MultiPlotWidget] = Plots
+    _TABLE_TYPE: Type[OriginalSignalsTable] = SignalsTable
 
-    def _make_plots(self) -> LinkedMultiPlotWidget:
+    def _make_plots(self) -> MultiPlotWidget:
         """Returns the plots widget. Optionally override to use a different plots widget."""
         return self._PLOT_TYPE()
 
-    def _make_table(self) -> SignalsTable:
+    def _make_table(self) -> OriginalSignalsTable:
         """Returns the signals table widget. Optionally override to use a different signals widget.
         Plots are created first, and this may reference plots."""
         return self._TABLE_TYPE(self._plots)

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -84,6 +84,8 @@ class SignalsTable(QTableWidget):
             header.setSectionResizeMode(col, QHeaderView.ResizeMode.Interactive)
 
         self._data_items: Dict[str, QColor] = {}
+
+        self._update()
         self._plots.sigDataItemsUpdated.connect(self._update)
 
     def _update(self) -> None:

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -26,7 +26,7 @@ from PySide6.QtWidgets import QTableWidgetItem, QTableWidget, QHeaderView, QMenu
 from pydantic import BaseModel
 
 from .cache_dict import IdentityCacheDict
-from .multi_plot_widget import MultiPlotWidget
+from .multi_plot_widget import MultiPlotWidget, LinkedMultiPlotWidget
 from .save_restore_model import BaseTopModel, DataTopModel, HasSaveLoadDataConfig
 from .util import not_none
 
@@ -103,10 +103,15 @@ class SignalsTable(QTableWidget):
 
 
 class HasRegionSignalsTable(SignalsTable):
-    """A SignalsTable that listens for a region change and provides some utilities"""
+    """Provides utilities for getting the region from a plot"""
 
-    def set_range(self, range: Tuple[float, float]) -> None:
-        self._range = range
+    @staticmethod
+    def _region_of_plot(plots: MultiPlotWidget) -> Tuple[float, float]:
+        """Returns the region of a plot, if the plot supports regions, otherwise returns (-inf, inf)."""
+        if isinstance(plots, LinkedMultiPlotWidget) and isinstance(plots._last_region, tuple):
+            return plots._last_region
+        else:
+            return (-float("inf"), float("inf"))
 
     @classmethod
     def _indices_of_region(
@@ -123,188 +128,6 @@ class HasRegionSignalsTable(SignalsTable):
             return None, None
         else:
             return low_index, high_index
-
-
-class HasDataSignalsTable(SignalsTable):
-    """A SignalsTable that stores a copy of the data"""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self._data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = {}
-
-    def set_data(
-        self,
-        data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
-    ) -> None:
-        self._data = data
-
-
-class StatsSignalsTable(HasRegionSignalsTable, HasDataSignalsTable):
-    """Mixin into SignalsTable with statistics rows. Optional range to specify computation of statistics.
-    Values passed into set_data must all be numeric."""
-
-    COL_STAT = -1
-    COL_STAT_MIN = 0  # offset from COL_STAT
-    COL_STAT_MAX = 1
-    COL_STAT_AVG = 2
-    COL_STAT_RMS = 3
-    COL_STAT_STDEV = 4
-    STATS_COLS = [
-        COL_STAT_MIN,
-        COL_STAT_MAX,
-        COL_STAT_AVG,
-        COL_STAT_RMS,
-        COL_STAT_STDEV,
-    ]
-
-    FULL_RANGE = (-float("inf"), float("inf"))
-
-    class StatsCalculatorSignals(QObject):
-        update = Signal(object, object, object)  # input array, region, {stat (by offset col) -> value}
-
-    class StatsCalculatorThread(QThread):
-        """Stats calculated in a separate thread to avoid blocking the main GUI thread when large regions
-        are selected.
-        This thread is persistent and monitors its queue for requests to work. Requests (near)immediately
-        override whatever previous computation was in progress and are not queued.
-        Thread sleeps when current task and queue is empty."""
-
-        class Task(NamedTuple):
-            """A request for computing statistics of some ys and region (over xs, inclusive).
-            data is stored as a weakref to terminate computation early if data goes out of scope"""
-
-            data: List[Tuple[weakref.ref[npt.NDArray[np.float64]], weakref.ref[npt.NDArray[np.float64]]]]
-            region: Tuple[float, float]
-
-        def __init__(self, parent: Any):
-            super().__init__(parent)
-            self.signals = StatsSignalsTable.StatsCalculatorSignals()
-            self.queue: queue.Queue[StatsSignalsTable.StatsCalculatorThread.Task] = queue.Queue()
-
-        def run(self) -> None:
-            while True:
-                task = self.queue.get()  # get at least one task, blocking
-                while not self.queue.empty():  # but get the latest, if multiple, discarding earlier
-                    task = self.queue.get()
-
-                for xs_ys_ref in task.data:
-                    if not self.queue.empty():  # new task, drop current task
-                        break
-
-                    xs = xs_ys_ref[0]()
-                    ys = xs_ys_ref[1]()
-                    if xs is None or ys is None:  # skip objects that have been deleted
-                        continue
-                    low_index, high_index = HasRegionSignalsTable._indices_of_region(xs, task.region)
-                    if low_index is None or high_index is None:  # empty set
-                        ys_region = np.array([])
-                    else:
-                        ys_region = ys[low_index:high_index]
-                    stats_dict = self._calculate_stats(ys_region)
-                    self.signals.update.emit(ys, task.region, stats_dict)
-
-        def terminate_wait(self) -> None:
-            self.terminate()
-            self.wait()  # needed otherwise pytest fails on Linux
-
-        @classmethod
-        def _calculate_stats(cls, ys: npt.NDArray[np.float64]) -> Dict[int, float]:
-            """Calculates stats (as dict of col offset -> value) for the specified xs, ys.
-            Does not spawn a separate thread, does not affect global state."""
-            if len(ys) == 0:
-                return {}
-            stats_dict = {}
-            mean = sum(ys) / len(ys)
-            stats_dict[StatsSignalsTable.COL_STAT_MIN] = min(ys)
-            stats_dict[StatsSignalsTable.COL_STAT_MAX] = max(ys)
-            stats_dict[StatsSignalsTable.COL_STAT_AVG] = mean
-            stats_dict[StatsSignalsTable.COL_STAT_RMS] = math.sqrt(sum([x**2 for x in ys]) / len(ys))
-            stats_dict[StatsSignalsTable.COL_STAT_STDEV] = math.sqrt(sum([(x - mean) ** 2 for x in ys]) / len(ys))
-            return stats_dict
-
-    def _post_cols(self) -> int:
-        self.COL_STAT = super()._post_cols()
-        return self.COL_STAT + 5
-
-    def _init_table(self) -> None:
-        super()._init_table()
-        self.setHorizontalHeaderItem(self.COL_STAT + self.COL_STAT_MIN, QTableWidgetItem("Min"))
-        self.setHorizontalHeaderItem(self.COL_STAT + self.COL_STAT_MAX, QTableWidgetItem("Max"))
-        self.setHorizontalHeaderItem(self.COL_STAT + self.COL_STAT_AVG, QTableWidgetItem("Avg"))
-        self.setHorizontalHeaderItem(self.COL_STAT + self.COL_STAT_RMS, QTableWidgetItem("RMS"))
-        self.setHorizontalHeaderItem(self.COL_STAT + self.COL_STAT_STDEV, QTableWidgetItem("StDev"))
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        # since calculating stats across the full range is VERY EXPENSIVE, cache the results
-        self._full_range_stats = IdentityCacheDict[npt.NDArray[np.float64], Dict[int, float]]()  # array -> stats dict
-        self._region_stats = IdentityCacheDict[npt.NDArray[np.float64], Dict[int, float]]()  # array -> stats dict
-        self._range: Tuple[float, float] = self.FULL_RANGE
-
-        self._stats_compute_thread = self.StatsCalculatorThread(self)
-        self._stats_compute_thread.signals.update.connect(self._on_stats_updated)
-        self._stats_compute_thread.start(QThread.Priority.IdlePriority)
-        self.destroyed.connect(lambda: self._stats_compute_thread.terminate_wait())
-
-    def _on_stats_updated(
-        self, input_arr: npt.NDArray[np.float64], region: Tuple[float, float], stats_dict: Dict[int, float]
-    ) -> None:
-        if region == self.FULL_RANGE:
-            self._full_range_stats.set(input_arr, None, [], stats_dict)
-        elif region == self._range:
-            self._region_stats.set(input_arr, region, [], stats_dict)
-
-        if region == self._range:  # update display as needed
-            self._update_stats()
-
-    def set_data(
-        self,
-        data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]],
-    ) -> None:
-        """Sets the data and updates statistics"""
-        super().set_data(data)
-        self._create_stats_task()
-        self._update_stats()
-
-    def set_range(self, range: Tuple[float, float]) -> None:
-        super().set_range(range)
-        self._create_stats_task()
-        self._update_stats()
-
-    def _create_stats_task(self) -> None:
-        if self._range == self.FULL_RANGE:  # for full range, deduplicate with cache
-            needed_stats = [
-                (weakref.ref(xs), weakref.ref(ys))
-                for name, (xs, ys) in self._data.items()
-                if self._full_range_stats.get(ys, None, []) is None
-            ]
-        else:
-            needed_stats = [(weakref.ref(xs), weakref.ref(ys)) for name, (xs, ys) in self._data.items()]
-        self._stats_compute_thread.queue.put(self.StatsCalculatorThread.Task(needed_stats, self._range))
-
-    def _render_value(self, data_name: str, value: float) -> str:
-        """Float-to-string conversion for a value. Optionally override this to provide smarter precision."""
-        return self._plots.render_value(data_name, value)
-
-    def _update_stats(self) -> None:
-        for row, name in enumerate(self._data_items.keys()):
-            xs, ys = self._data.get(name, (None, None))
-            if xs is None or ys is None:
-                for col in self.STATS_COLS:
-                    not_none(self.item(row, self.COL_STAT + col)).setText("")
-                continue
-
-            if self._range == self.FULL_RANGE:  # fetch from cache if available
-                stats_dict: Dict[int, float] = self._full_range_stats.get(ys, None, [], {})
-            else:  # slice
-                stats_dict = self._region_stats.get(ys, self._range, [], {})
-
-            for col_offset in self.STATS_COLS:
-                if col_offset in stats_dict:
-                    text_value = self._render_value(name, stats_dict[col_offset])
-                else:
-                    text_value = ""
-                not_none(self.item(row, self.COL_STAT + col_offset)).setText(text_value)
 
 
 class ContextMenuSignalsTable(SignalsTable):

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -13,19 +13,15 @@
 #    limitations under the License.
 
 import bisect
-import math
-import queue
-import weakref
-from typing import Dict, Tuple, List, Any, Mapping, Optional, NamedTuple
+from typing import Dict, Tuple, List, Any, Optional
 
 import numpy as np
 import numpy.typing as npt
-from PySide6.QtCore import QMimeData, QPoint, Signal, QObject, QThread
+from PySide6.QtCore import QMimeData, QPoint, Signal
 from PySide6.QtGui import QColor, Qt, QAction, QDrag, QPixmap, QMouseEvent
 from PySide6.QtWidgets import QTableWidgetItem, QTableWidget, QHeaderView, QMenu, QLabel, QColorDialog
 from pydantic import BaseModel
 
-from .cache_dict import IdentityCacheDict
 from .multi_plot_widget import MultiPlotWidget, LinkedMultiPlotWidget
 from .save_restore_model import BaseTopModel, DataTopModel, HasSaveLoadDataConfig
 from .util import not_none
@@ -88,9 +84,10 @@ class SignalsTable(QTableWidget):
             header.setSectionResizeMode(col, QHeaderView.ResizeMode.Interactive)
 
         self._data_items: Dict[str, QColor] = {}
+        self._plots.sigDataItemsUpdated.connect(self._update)
 
-    def set_data_items(self, new_data_items: List[Tuple[str, QColor]]) -> None:
-        self._data_items = {data_name: color for data_name, color in new_data_items}
+    def _update(self) -> None:
+        self._data_items = {data_name: color for data_name, (color, _) in self._plots._data_items.items()}
 
         self.setRowCount(0)  # clear the existing table, other resizing becomes really expensive
         self.setRowCount(len(self._data_items))  # create new items

--- a/pyqtgraph_scope_plots/stats_signals_table.py
+++ b/pyqtgraph_scope_plots/stats_signals_table.py
@@ -160,6 +160,8 @@ class StatsSignalsTable(HasRegionSignalsTable):
         self._stats_compute_thread.queue.put(self.StatsCalculatorThread.Task(needed_stats, region))
 
     def _update_stats(self) -> None:
+        self._create_stats_task()
+
         for row, name in enumerate(self._data_items.keys()):
             xs, ys = self._plots._data.get(name, (None, None))
             if xs is None or ys is None:

--- a/pyqtgraph_scope_plots/stats_signals_table.py
+++ b/pyqtgraph_scope_plots/stats_signals_table.py
@@ -1,0 +1,186 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import bisect
+import math
+import queue
+import weakref
+from typing import Dict, Tuple, List, Any, Mapping, Optional, NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+from PySide6.QtCore import QMimeData, QPoint, Signal, QObject, QThread
+from PySide6.QtGui import QColor, Qt, QAction, QDrag, QPixmap, QMouseEvent
+from PySide6.QtWidgets import QTableWidgetItem, QTableWidget, QHeaderView, QMenu, QLabel, QColorDialog
+from pydantic import BaseModel
+
+from .cache_dict import IdentityCacheDict
+from .multi_plot_widget import MultiPlotWidget
+from .save_restore_model import BaseTopModel, DataTopModel, HasSaveLoadDataConfig
+from .signals_table import HasRegionSignalsTable
+from .util import not_none
+
+
+class StatsSignalsTable(HasRegionSignalsTable):
+    """Mixin into SignalsTable with statistics rows. Optional range to specify computation of statistics.
+    Values passed into set_data must all be numeric."""
+
+    COL_STAT = -1
+    COL_STAT_MIN = 0  # offset from COL_STAT
+    COL_STAT_MAX = 1
+    COL_STAT_AVG = 2
+    COL_STAT_RMS = 3
+    COL_STAT_STDEV = 4
+    STATS_COLS = [
+        COL_STAT_MIN,
+        COL_STAT_MAX,
+        COL_STAT_AVG,
+        COL_STAT_RMS,
+        COL_STAT_STDEV,
+    ]
+
+    _FULL_RANGE = (-float("inf"), float("inf"))
+
+    class StatsCalculatorSignals(QObject):
+        update = Signal(object, object, object)  # input array, region, {stat (by offset col) -> value}
+
+    class StatsCalculatorThread(QThread):
+        """Stats calculated in a separate thread to avoid blocking the main GUI thread when large regions
+        are selected.
+        This thread is persistent and monitors its queue for requests to work. Requests (near)immediately
+        override whatever previous computation was in progress and are not queued.
+        Thread sleeps when current task and queue is empty."""
+
+        class Task(NamedTuple):
+            """A request for computing statistics of some ys and region (over xs, inclusive).
+            data is stored as a weakref to terminate computation early if data goes out of scope"""
+
+            data: List[Tuple[weakref.ref[npt.NDArray[np.float64]], weakref.ref[npt.NDArray[np.float64]]]]
+            region: Tuple[float, float]
+
+        def __init__(self, parent: Any):
+            super().__init__(parent)
+            self.signals = StatsSignalsTable.StatsCalculatorSignals()
+            self.queue: queue.Queue[StatsSignalsTable.StatsCalculatorThread.Task] = queue.Queue()
+
+        def run(self) -> None:
+            while True:
+                task = self.queue.get()  # get at least one task, blocking
+                while not self.queue.empty():  # but get the latest, if multiple, discarding earlier
+                    task = self.queue.get()
+
+                for xs_ys_ref in task.data:
+                    if not self.queue.empty():  # new task, drop current task
+                        break
+
+                    xs = xs_ys_ref[0]()
+                    ys = xs_ys_ref[1]()
+                    if xs is None or ys is None:  # skip objects that have been deleted
+                        continue
+                    low_index, high_index = HasRegionSignalsTable._indices_of_region(xs, task.region)
+                    if low_index is None or high_index is None:  # empty set
+                        ys_region = np.array([])
+                    else:
+                        ys_region = ys[low_index:high_index]
+                    stats_dict = self._calculate_stats(ys_region)
+                    self.signals.update.emit(ys, task.region, stats_dict)
+
+        def terminate_wait(self) -> None:
+            self.terminate()
+            self.wait()  # needed otherwise pytest fails on Linux
+
+        @classmethod
+        def _calculate_stats(cls, ys: npt.NDArray[np.float64]) -> Dict[int, float]:
+            """Calculates stats (as dict of col offset -> value) for the specified xs, ys.
+            Does not spawn a separate thread, does not affect global state."""
+            if len(ys) == 0:
+                return {}
+            stats_dict = {}
+            mean = sum(ys) / len(ys)
+            stats_dict[StatsSignalsTable.COL_STAT_MIN] = min(ys)
+            stats_dict[StatsSignalsTable.COL_STAT_MAX] = max(ys)
+            stats_dict[StatsSignalsTable.COL_STAT_AVG] = mean
+            stats_dict[StatsSignalsTable.COL_STAT_RMS] = math.sqrt(sum([x**2 for x in ys]) / len(ys))
+            stats_dict[StatsSignalsTable.COL_STAT_STDEV] = math.sqrt(sum([(x - mean) ** 2 for x in ys]) / len(ys))
+            return stats_dict
+
+    def _post_cols(self) -> int:
+        self.COL_STAT = super()._post_cols()
+        return self.COL_STAT + 5
+
+    def _init_table(self) -> None:
+        super()._init_table()
+        self.setHorizontalHeaderItem(self.COL_STAT + self.COL_STAT_MIN, QTableWidgetItem("Min"))
+        self.setHorizontalHeaderItem(self.COL_STAT + self.COL_STAT_MAX, QTableWidgetItem("Max"))
+        self.setHorizontalHeaderItem(self.COL_STAT + self.COL_STAT_AVG, QTableWidgetItem("Avg"))
+        self.setHorizontalHeaderItem(self.COL_STAT + self.COL_STAT_RMS, QTableWidgetItem("RMS"))
+        self.setHorizontalHeaderItem(self.COL_STAT + self.COL_STAT_STDEV, QTableWidgetItem("StDev"))
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # since calculating stats across the full range is VERY EXPENSIVE, cache the results
+        self._full_range_stats = IdentityCacheDict[npt.NDArray[np.float64], Dict[int, float]]()  # array -> stats dict
+        self._region_stats = IdentityCacheDict[npt.NDArray[np.float64], Dict[int, float]]()  # array -> stats dict
+
+        self._plots.sigDataUpdated.connect(self._update_stats)
+        self._plots.sigCursorRangeChanged.connect(self._update_stats)
+
+        self._stats_compute_thread = self.StatsCalculatorThread(self)
+        self._stats_compute_thread.signals.update.connect(self._on_stats_updated)
+        self._stats_compute_thread.start(QThread.Priority.IdlePriority)
+        self.destroyed.connect(lambda: self._stats_compute_thread.terminate_wait())
+
+    def _on_stats_updated(
+        self, input_arr: npt.NDArray[np.float64], input_region: Tuple[float, float], stats_dict: Dict[int, float]
+    ) -> None:
+        region = HasRegionSignalsTable._region_of_plot(self._plots)
+        if input_region == self._FULL_RANGE:
+            self._full_range_stats.set(input_arr, None, [], stats_dict)
+        elif input_region == region:
+            self._region_stats.set(input_arr, region, [], stats_dict)
+        if input_region == region:  # update display as needed
+            self._update_stats()
+
+    def _create_stats_task(self) -> None:
+        region = HasRegionSignalsTable._region_of_plot(self._plots)
+        if region == self._FULL_RANGE:  # for full range, deduplicate with cache
+            needed_stats = [
+                (weakref.ref(xs), weakref.ref(ys))
+                for name, (xs, ys) in self._plots._data.items()
+                if self._full_range_stats.get(ys, None, []) is None
+            ]
+        else:
+            needed_stats = [(weakref.ref(xs), weakref.ref(ys)) for name, (xs, ys) in self._plots._data.items()]
+        self._stats_compute_thread.queue.put(self.StatsCalculatorThread.Task(needed_stats, region))
+
+    def _update_stats(self) -> None:
+        for row, name in enumerate(self._data_items.keys()):
+            xs, ys = self._plots._data.get(name, (None, None))
+            if xs is None or ys is None:
+                for col in self.STATS_COLS:
+                    not_none(self.item(row, self.COL_STAT + col)).setText("")
+                continue
+
+            region = HasRegionSignalsTable._region_of_plot(self._plots)
+            if region == self._FULL_RANGE:  # fetch from cache if available
+                stats_dict: Dict[int, float] = self._full_range_stats.get(ys, None, [], {})
+            else:  # slice
+                stats_dict = self._region_stats.get(ys, region, [], {})
+
+            for col_offset in self.STATS_COLS:
+                if col_offset in stats_dict:
+                    text_value = self._plots.render_value(name, stats_dict[col_offset])
+                else:
+                    text_value = ""
+                not_none(self.item(row, self.COL_STAT + col_offset)).setText(text_value)

--- a/pyqtgraph_scope_plots/stats_signals_table.py
+++ b/pyqtgraph_scope_plots/stats_signals_table.py
@@ -12,22 +12,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import bisect
 import math
 import queue
 import weakref
-from typing import Dict, Tuple, List, Any, Mapping, Optional, NamedTuple
+from typing import Dict, Tuple, List, Any, NamedTuple
 
 import numpy as np
 import numpy.typing as npt
-from PySide6.QtCore import QMimeData, QPoint, Signal, QObject, QThread
-from PySide6.QtGui import QColor, Qt, QAction, QDrag, QPixmap, QMouseEvent
-from PySide6.QtWidgets import QTableWidgetItem, QTableWidget, QHeaderView, QMenu, QLabel, QColorDialog
-from pydantic import BaseModel
+from PySide6.QtCore import Signal, QObject, QThread
+from PySide6.QtWidgets import QTableWidgetItem
 
 from .cache_dict import IdentityCacheDict
-from .multi_plot_widget import MultiPlotWidget
-from .save_restore_model import BaseTopModel, DataTopModel, HasSaveLoadDataConfig
 from .signals_table import HasRegionSignalsTable
 from .util import not_none
 

--- a/pyqtgraph_scope_plots/timeshift_signals_table.py
+++ b/pyqtgraph_scope_plots/timeshift_signals_table.py
@@ -37,12 +37,12 @@ class TimeshiftPlotWidget(LinkedMultiPlotWidget, HasSaveLoadDataConfig):
     _DATA_MODEL_BASES = [TimeshiftDataStateModel]
 
     def __init__(self, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
-
         self._timeshifts: Dict[str, float] = {}  # data name -> time delay
         self._timeshifts_cached_results = IdentityCacheDict[
             npt.NDArray[np.float64], npt.NDArray[np.float64]
         ]()  # src x-values -> output x-values
+
+        super().__init__(*args, **kwargs)
 
         # state variables for timeshift drag handle
         self._timeshifts_drag_data_items: List[str] = []

--- a/pyqtgraph_scope_plots/timeshift_signals_table.py
+++ b/pyqtgraph_scope_plots/timeshift_signals_table.py
@@ -127,7 +127,6 @@ class TimeshiftPlotWidget(LinkedMultiPlotWidget, HasSaveLoadDataConfig):
         self.create_drag_cursor(handle_pos)
 
     def _on_timeshift_drag(self, pos: float) -> None:
-        print(pos)
         self.set_timeshift(self._timeshifts_drag_data_items, pos - self._timeshifts_drag_offset)
 
     def _on_timeshift_drag_clear(self) -> None:

--- a/pyqtgraph_scope_plots/timeshift_signals_table.py
+++ b/pyqtgraph_scope_plots/timeshift_signals_table.py
@@ -16,12 +16,12 @@ from typing import Dict, List, Any, Mapping, Tuple, Optional
 
 import numpy as np
 import numpy.typing as npt
-from PySide6.QtGui import QAction, QColor
+from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QTableWidgetItem, QMenu
 from pydantic import BaseModel
 
 from .cache_dict import IdentityCacheDict
-from .multi_plot_widget import MultiPlotWidget, LinkedMultiPlotWidget
+from .multi_plot_widget import LinkedMultiPlotWidget
 from .save_restore_model import DataTopModel, HasSaveLoadDataConfig, BaseTopModel
 from .signals_table import ContextMenuSignalsTable
 from .util import not_none

--- a/pyqtgraph_scope_plots/transforms_signal_table.py
+++ b/pyqtgraph_scope_plots/transforms_signal_table.py
@@ -90,21 +90,23 @@ class TransformsPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
         ]()  # src data -> output data
 
     def _write_model(self, model: BaseModel) -> None:
-        assert isinstance(model, BaseTopModel)
         super()._write_model(model)
+        assert isinstance(model, BaseTopModel)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, TransformsDataStateModel)
             transform, _ = self._transforms.get(data_name, ("", None))
             data_model.transform = transform
 
     def _load_model(self, model: BaseModel) -> None:
-        assert isinstance(model, BaseTopModel)
         super()._load_model(model)
+        assert isinstance(model, BaseTopModel)
         for data_name, data_model in model.data.items():
             assert isinstance(data_model, TransformsDataStateModel)
-            # TODO improve robustness to SyntaxError
             if data_model.transform is not None:
-                self.set_transform([data_name], data_model.transform, update=False)
+                try:
+                    self.set_transform([data_name], data_model.transform, update=False)
+                except Exception as e:
+                    pass  # TODO some kind of logging / warning
 
     def apply_transform(
         self,

--- a/pyqtgraph_scope_plots/transforms_signal_table.py
+++ b/pyqtgraph_scope_plots/transforms_signal_table.py
@@ -79,8 +79,6 @@ class TransformsPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
     _DATA_MODEL_BASES = [TransformsDataStateModel]
 
     def __init__(self, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
-
         self._simpleeval = simpleeval.SimpleEval()
 
         self._transforms: Dict[str, Tuple[str, Any]] = {}  # (expr str, parsed)
@@ -88,6 +86,8 @@ class TransformsPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
         self._transforms_cached_results = IdentityCacheDict[
             npt.NDArray[np.float64], npt.NDArray[np.float64]
         ]()  # src data -> output data
+
+        super().__init__(*args, **kwargs)
 
     def _write_model(self, model: BaseModel) -> None:
         super()._write_model(model)

--- a/pyqtgraph_scope_plots/transforms_signal_table.py
+++ b/pyqtgraph_scope_plots/transforms_signal_table.py
@@ -154,6 +154,7 @@ class TransformsPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
     ) -> Mapping[str, Tuple[npt.NDArray, npt.NDArray]]:
         data = super()._transform_data(data)
         transformed_data = {}
+        last_transform_errs = self._transforms_errs
         for data_name in data.keys():
             transformed = self._apply_transform(data_name, data)
             if isinstance(transformed, Exception):
@@ -163,6 +164,8 @@ class TransformsPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
                 if data_name in self._transforms_errs:
                     del self._transforms_errs[data_name]
             transformed_data[data_name] = data[data_name][0], transformed
+        if len(last_transform_errs) > 0 or len(self._transforms_errs) > 0:
+            self.sigDataUpdated.emit()  # error counts as a transform update
         return transformed_data
 
     def set_transform(self, data_names: List[str], transform_expr: str, update: bool = True) -> None:

--- a/pyqtgraph_scope_plots/transforms_signal_table.py
+++ b/pyqtgraph_scope_plots/transforms_signal_table.py
@@ -106,7 +106,7 @@ class TransformsPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
                 try:
                     self.set_transform([data_name], data_model.transform, update=False)
                 except Exception as e:
-                    pass  # TODO some kind of logging / warning
+                    print(f"failed to restore transform fn {data_model.transform}: {e}")  # TODO better logging
 
     def _apply_transform(
         self,

--- a/pyqtgraph_scope_plots/transforms_signal_table.py
+++ b/pyqtgraph_scope_plots/transforms_signal_table.py
@@ -152,7 +152,7 @@ class TransformsPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
     ) -> Mapping[str, Tuple[npt.NDArray, npt.NDArray]]:
         transformed_data = {}
         for data_name in data.keys():
-            transformed = self._table.apply_transform(data_name, data)
+            transformed = self.apply_transform(data_name, data)
             if isinstance(transformed, Exception):
                 continue
             transformed_data[data_name] = data[data_name][0], transformed
@@ -175,6 +175,7 @@ class TransformsPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
                 self._transforms[data_name] = (transform_expr, parsed)
 
         if update:
+            self._update_plots()
             self.sigDataUpdated.emit()
             self.sigDataItemsUpdated.emit()
 

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -94,13 +94,6 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
             self._update()
         self.sigXyDataItemsChanged.emit()
 
-    def _get_region(self) -> Tuple[float, float]:
-        """Gets the currently selected region from the plot, or (-inf, inf) by default."""
-        if isinstance(self._plots, LinkedMultiPlotWidget) and isinstance(self._plots._last_region, tuple):
-            return self._plots._last_region
-        else:
-            return (-float("inf"), float("inf"))
-
     @staticmethod
     def _get_correlated_indices(
         x_ts: npt.NDArray[np.float64], y_ts: npt.NDArray[np.float64], start: float, end: float
@@ -124,7 +117,7 @@ class XyPlotWidget(BaseXyPlot, pg.PlotWidget):  # type: ignore[misc]
         for data_item in self.listDataItems():  # clear existing
             self.removeItem(data_item)
 
-        region = self._get_region()
+        region = HasRegionSignalsTable._region_of_plot(self._plots)
         data = self._plots._data
         for x_name, y_name in self._xys:
             x_ts, x_ys = data.get(x_name, (None, None))

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -97,7 +97,7 @@ class RefGeoXyPlotWidget(XyPlotWidget):
     def _update(self) -> None:
         super()._update()  # data items drawn here
 
-        region = self._get_region()
+        region = HasRegionSignalsTable._region_of_plot(self._plots)
 
         def get_data_region(ts: npt.NDArray[np.float64], ys: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
             """Given ts and xs of a data item, return ys bounded to the input region."""

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -67,7 +67,7 @@ class RefGeoXyPlotWidget(XyPlotWidget):
             try:
                 self.set_ref_geometry_fn(expr, update=False)
             except Exception as e:
-                pass  # TODO some kind of logging / warning
+                print(f"failed to restore ref geometry fn {expr}: {e}")  # TODO better logging
 
         # bulk update
         self._update()

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -169,8 +169,9 @@ class RefGeoXyPlotTable(ContextMenuXyPlotTable, XyPlotTable):
         text = ""
         if index is not None:
             text = self._xy_plots._refgeo_fns[index][0]
-        err_msg = ""
         fn_help_str = "\n".join([f"- {fn.__doc__}" for fn_name, fn in self._xy_plots._SIMPLEEVAL_FNS.items()])
+
+        err_msg = ""
         while True:
             text, ok = QInputDialog().getText(
                 self,
@@ -183,9 +184,9 @@ class RefGeoXyPlotTable(ContextMenuXyPlotTable, XyPlotTable):
             )
             if not ok:
                 return
-            else:
-                try:
-                    self._xy_plots.set_ref_geometry_fn(text, index)
-                    return
-                except SyntaxError as exc:
-                    err_msg = f"\n\n{exc.__class__.__name__}: {exc}"
+
+            try:
+                self._xy_plots.set_ref_geometry_fn(text, index)
+                return
+            except SyntaxError as exc:
+                err_msg = f"\n\n{exc.__class__.__name__}: {exc}"

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -67,7 +67,7 @@ class RefGeoXyPlotWidget(XyPlotWidget):
             try:
                 self.set_ref_geometry_fn(expr, update=False)
             except Exception as e:
-                pass  # ignore
+                pass  # TODO some kind of logging / warning
 
         # bulk update
         self._update()

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -104,108 +104,6 @@ def test_data_signals(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     qtbot.waitSignals([plot._plots.sigDataItemsUpdated, plot._plots.sigDataUpdated])
 
 
-def test_plot_merge(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    qtbot.waitUntil(lambda: plot._plots.count() == 3)  # wait for plots to be ready
-
-    plot._plots._merge_data_into_item(["0"], 1)  # merge
-    qtbot.waitUntil(lambda: plot._plots.count() == 2)  # wait for widgets to merge
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 2
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(1)).getPlotItem()).listDataItems()) == 1
-    assert plot._table.rowCount() == 3  # signals table should not change
-    assert plot._table.item(0, plot._table.COL_NAME).text() == "0"
-    assert plot._table.item(1, plot._table.COL_NAME).text() == "1"
-    assert plot._table.item(2, plot._table.COL_NAME).text() == "2"
-
-    plot._plots._merge_data_into_item(["0"], 1)  # move
-    qtbot.waitUntil(lambda: plot._plots.count() == 2)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 1
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(1)).getPlotItem()).listDataItems()) == 2
-    assert plot._table.rowCount() == 3  # signals table should not change
-    assert plot._table.item(0, plot._table.COL_NAME).text() == "0"
-    assert plot._table.item(1, plot._table.COL_NAME).text() == "1"
-    assert plot._table.item(2, plot._table.COL_NAME).text() == "2"
-
-    plot._plots._merge_data_into_item(["1"], 1)  # merge all
-    qtbot.waitUntil(lambda: plot._plots.count() == 1)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 3
-    assert plot._table.rowCount() == 3  # signals table should not change
-    assert plot._table.item(0, plot._table.COL_NAME).text() == "0"
-    assert plot._table.item(1, plot._table.COL_NAME).text() == "1"
-    assert plot._table.item(2, plot._table.COL_NAME).text() == "2"
-
-    plot._plots._merge_data_into_item(["2"], 0, insert=True)  # insert at top
-    qtbot.waitUntil(lambda: plot._plots.count() == 2)  # new plot created
-    assert plot._table.rowCount() == 3  # signals table should not change
-    assert plot._table.item(0, plot._table.COL_NAME).text() == "0"
-    assert plot._table.item(1, plot._table.COL_NAME).text() == "1"
-    assert plot._table.item(2, plot._table.COL_NAME).text() == "2"
-
-    plot._plots._merge_data_into_item(["0"], 2, insert=True)  # insert at bottom
-    qtbot.waitUntil(lambda: plot._plots.count() == 3)
-
-
-def test_plot_merge_multi(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    qtbot.waitUntil(lambda: plot._plots.count() == 3)  # wait for plots to be ready
-
-    plot._plots._merge_data_into_item(["0", "1"], 0)  # merge into self, including self
-    qtbot.waitUntil(lambda: plot._plots.count() == 2)  # wait for widgets to merge
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 2
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(1)).getPlotItem()).listDataItems()) == 1
-
-    plot._plots._merge_data_into_item(["0", "1"], 1)  # merge into other, not including self
-    qtbot.waitUntil(lambda: plot._plots.count() == 1)  # wait for widgets to merge
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 3
-
-    plot._plots._merge_data_into_item(["1", "2"], 2, insert=True)  # insert at bottom
-    qtbot.waitUntil(lambda: plot._plots.count() == 2)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 1
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(1)).getPlotItem()).listDataItems()) == 2
-
-    plot._plots._merge_data_into_item(["0", "1", "2"], 2, insert=True)  # insert all
-    qtbot.waitUntil(lambda: plot._plots.count() == 1)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 3
-
-
-def test_invalid_plot_merge(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    plot._set_data_items(
-        [
-            ("0", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
-            ("1", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
-            ("2", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
-            ("3", QColor("cyan"), MultiPlotWidget.PlotType.ENUM_WAVEFORM),
-            ("4", QColor("brown"), MultiPlotWidget.PlotType.ENUM_WAVEFORM),
-        ]
-    )
-
-    qtbot.waitUntil(lambda: plot._plots.count() == 5)  # wait for plots to be ready
-
-    plot._plots._merge_data_into_item(["3"], 0)  # invalid merge, different types
-    plot._plots._merge_data_into_item(["0"], 3)  # invalid merge, different types
-    plot._plots._merge_data_into_item(["3"], 4)  # can't merge enums
-    plot._plots._merge_data_into_item(["4"], 3)  # can't merge enums
-
-    assert plot._plots.count() == 5  # check nothing changes
-
-
-def test_plot_remove(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    plot._plots.remove_plot_items(["1"])
-    qtbot.waitUntil(lambda: plot._plots.count() == 2)  # plot removed
-
-    plot._plots._merge_data_into_item(["2"], 0)  # merge all into top
-    qtbot.waitUntil(lambda: plot._plots.count() == 1)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 2
-
-    plot._plots.remove_plot_items(["0"])
-    qtbot.waitUntil(
-        lambda: len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 1
-    )
-
-    plot._plots.remove_plot_items(["2"])  # delete the last plot, the empty plot should appear
-    qtbot.waitUntil(
-        lambda: len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 0
-    )
-
-
 def test_plot_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     qtbot.waitUntil(
         lambda: cast(MultiPlotStateModel, plot._plots._dump_data_model([])).plot_widgets
@@ -214,18 +112,6 @@ def test_plot_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
             PlotWidgetModel(data_items=["1"], y_range="auto"),
             PlotWidgetModel(data_items=["2"], y_range="auto"),
         ]
-    )
-
-    plot._plots._merge_data_into_item(["0"], 1)  # merge
-    qtbot.waitUntil(
-        lambda: cast(MultiPlotStateModel, plot._plots._dump_data_model([])).plot_widgets
-        == [PlotWidgetModel(data_items=["1", "0"], y_range="auto"), PlotWidgetModel(data_items=["2"], y_range="auto")]
-    )
-
-    plot._plots._merge_data_into_item(["2"], 0)  # merge
-    qtbot.waitUntil(
-        lambda: cast(MultiPlotStateModel, plot._plots._dump_data_model([])).plot_widgets
-        == [PlotWidgetModel(data_items=["1", "0", "2"], y_range="auto")]
     )
 
 
@@ -294,10 +180,6 @@ def test_no_excessive_plots(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
     qtbot.waitUntil(lambda: plot._plots.count() == 1)  # should just create an empty plot
     assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 0
-
-    plot._plots._merge_data_into_item(["A"], 0)  # check that stuff can be dragged into the default empty plot
-    qtbot.waitUntil(lambda: plot._plots.count() == 1)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 1
 
 
 def test_export_csv(qtbot: QtBot, plot: PlotsTableWidget) -> None:

--- a/tests/test_droppable_plot.py
+++ b/tests/test_droppable_plot.py
@@ -1,0 +1,182 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from io import StringIO
+from typing import cast
+
+import pyqtgraph as pg
+import pytest
+from PySide6.QtGui import QColor
+from pytestqt.qtbot import QtBot
+
+from pyqtgraph_scope_plots.multi_plot_widget import (
+    MultiPlotWidget,
+    MultiPlotStateModel,
+    PlotWidgetModel,
+    DroppableMultiPlotWidget,
+)
+from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
+from pyqtgraph_scope_plots.signals_table import SignalsTable
+from .test_util import assert_cast
+
+
+@pytest.fixture()
+def plots(qtbot: QtBot) -> DroppableMultiPlotWidget:
+    """Creates a signals plot with multiple data items"""
+    plots = DroppableMultiPlotWidget()
+    plots.show_data_items(
+        [
+            ("0", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
+            ("1", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
+            ("2", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
+        ]
+    )
+    plots.set_data(
+        {
+            "0": ([0, 0.1, 1, 2], [0.01, 1, 1, 0]),
+            "1": ([0, 1, 2], [0.5, 0.25, 0.5]),
+            "2": ([0, 1, 2], [0.7, 0.6, 0.5]),
+        }
+    )
+    qtbot.addWidget(plots)
+    plots.show()
+    qtbot.waitExposed(plots)
+    return plots
+
+
+def test_plot_merge(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None:
+    table = SignalsTable(plots)
+
+    qtbot.waitUntil(lambda: plots.count() == 3)  # wait for plots to be ready
+
+    plots._merge_data_into_item(["0"], 1)  # merge
+    qtbot.waitUntil(lambda: plots.count() == 2)  # wait for widgets to merge
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 2
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 1
+    assert table.rowCount() == 3  # signals table should not change
+    assert table.item(0, table.COL_NAME).text() == "0"
+    assert table.item(1, table.COL_NAME).text() == "1"
+    assert table.item(2, table.COL_NAME).text() == "2"
+
+    plots._merge_data_into_item(["0"], 1)  # move
+    qtbot.waitUntil(lambda: plots.count() == 2)
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 1
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 2
+    assert table.rowCount() == 3  # signals table should not change
+    assert table.item(0, table.COL_NAME).text() == "0"
+    assert table.item(1, table.COL_NAME).text() == "1"
+    assert table.item(2, table.COL_NAME).text() == "2"
+
+    plots._merge_data_into_item(["1"], 1)  # merge all
+    qtbot.waitUntil(lambda: plots.count() == 1)
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 3
+    assert table.rowCount() == 3  # signals table should not change
+    assert table.item(0, table.COL_NAME).text() == "0"
+    assert table.item(1, table.COL_NAME).text() == "1"
+    assert table.item(2, table.COL_NAME).text() == "2"
+
+    plots._merge_data_into_item(["2"], 0, insert=True)  # insert at top
+    qtbot.waitUntil(lambda: plots.count() == 2)  # new plot created
+    assert table.rowCount() == 3  # signals table should not change
+    assert table.item(0, table.COL_NAME).text() == "0"
+    assert table.item(1, table.COL_NAME).text() == "1"
+    assert table.item(2, table.COL_NAME).text() == "2"
+
+    plots._merge_data_into_item(["0"], 2, insert=True)  # insert at bottom
+    qtbot.waitUntil(lambda: plots.count() == 3)
+
+
+def test_plot_merge_multi(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None:
+    qtbot.waitUntil(lambda: plots.count() == 3)  # wait for plots to be ready
+
+    plots._merge_data_into_item(["0", "1"], 0)  # merge into self, including self
+    qtbot.waitUntil(lambda: plots.count() == 2)  # wait for widgets to merge
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 2
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 1
+
+    plots._merge_data_into_item(["0", "1"], 1)  # merge into other, not including self
+    qtbot.waitUntil(lambda: plots.count() == 1)  # wait for widgets to merge
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 3
+
+    plots._merge_data_into_item(["1", "2"], 2, insert=True)  # insert at bottom
+    qtbot.waitUntil(lambda: plots.count() == 2)
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 1
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 2
+
+    plots._merge_data_into_item(["0", "1", "2"], 2, insert=True)  # insert all
+    qtbot.waitUntil(lambda: plots.count() == 1)
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 3
+
+
+def test_invalid_plot_merge(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None:
+    plots.show_data_items(
+        [
+            ("0", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
+            ("1", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
+            ("2", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
+            ("3", QColor("cyan"), MultiPlotWidget.PlotType.ENUM_WAVEFORM),
+            ("4", QColor("brown"), MultiPlotWidget.PlotType.ENUM_WAVEFORM),
+        ]
+    )
+
+    qtbot.waitUntil(lambda: plots.count() == 5)  # wait for plots to be ready
+
+    plots._merge_data_into_item(["3"], 0)  # invalid merge, different types
+    plots._merge_data_into_item(["0"], 3)  # invalid merge, different types
+    plots._merge_data_into_item(["3"], 4)  # can't merge enums
+    plots._merge_data_into_item(["4"], 3)  # can't merge enums
+
+    assert plots.count() == 5  # check nothing changes
+
+
+def test_plot_remove(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None:
+    plots.remove_plot_items(["1"])
+    qtbot.waitUntil(lambda: plots.count() == 2)  # plot removed
+
+    plots._merge_data_into_item(["2"], 0)  # merge all into top
+    qtbot.waitUntil(lambda: plots.count() == 1)
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 2
+
+    plots.remove_plot_items(["0"])
+    qtbot.waitUntil(
+        lambda: len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 1
+    )
+
+    plots.remove_plot_items(["2"])  # delete the last plot, the empty plot should appear
+    qtbot.waitUntil(
+        lambda: len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 0
+    )
+
+
+def test_plot_save(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None:
+    qtbot.waitUntil(
+        lambda: cast(MultiPlotStateModel, plots._dump_data_model([])).plot_widgets
+        == [
+            PlotWidgetModel(data_items=["0"], y_range="auto"),
+            PlotWidgetModel(data_items=["1"], y_range="auto"),
+            PlotWidgetModel(data_items=["2"], y_range="auto"),
+        ]
+    )
+
+    plots._merge_data_into_item(["0"], 1)  # merge
+    qtbot.waitUntil(
+        lambda: cast(MultiPlotStateModel, plots._dump_data_model([])).plot_widgets
+        == [PlotWidgetModel(data_items=["1", "0"], y_range="auto"), PlotWidgetModel(data_items=["2"], y_range="auto")]
+    )
+
+    plots._merge_data_into_item(["2"], 0)  # merge
+    qtbot.waitUntil(
+        lambda: cast(MultiPlotStateModel, plots._dump_data_model([])).plot_widgets
+        == [PlotWidgetModel(data_items=["1", "0", "2"], y_range="auto")]
+    )

--- a/tests/test_stats_table.py
+++ b/tests/test_stats_table.py
@@ -1,0 +1,51 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import pytest
+from PySide6.QtGui import QColor
+from pytestqt.qtbot import QtBot
+
+from pyqtgraph_scope_plots import StatsSignalsTable
+from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
+from .test_transforms import DATA
+
+
+@pytest.fixture()
+def table(qtbot: QtBot) -> StatsSignalsTable:
+    """Creates a signals plot with multiple data items"""
+    plots = MultiPlotWidget()
+    table = StatsSignalsTable(plots)
+    plots.show_data_items(
+        [
+            ("0", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
+            ("1", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
+            ("2", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
+        ]
+    )
+    plots.set_data(DATA)
+    qtbot.addWidget(table)
+    table.show()
+    qtbot.waitExposed(table)
+    return table
+
+
+def test_full_range(qtbot: QtBot, table: StatsSignalsTable) -> None:
+    qtbot.waitUntil(lambda: table.rowCount() == 3)
+
+    qtbot.waitUntil(lambda: table.item(0, table.COL_STAT + table.COL_STAT_MIN).text() != "")
+    assert float(table.item(0, table.COL_STAT + table.COL_STAT_MIN).text()) == 0
+    assert float(table.item(0, table.COL_STAT + table.COL_STAT_MAX).text()) == 1
+    assert float(table.item(0, table.COL_STAT + table.COL_STAT_AVG).text()) == 0.5025
+    assert float(table.item(0, table.COL_STAT + table.COL_STAT_RMS).text()) == pytest.approx(0.707, 0.01)
+    assert float(table.item(0, table.COL_STAT + table.COL_STAT_STDEV).text()) == pytest.approx(0, 0.01)  # TODO

--- a/tests/test_stats_table.py
+++ b/tests/test_stats_table.py
@@ -16,8 +16,9 @@ import pytest
 from PySide6.QtGui import QColor
 from pytestqt.qtbot import QtBot
 
-from pyqtgraph_scope_plots import StatsSignalsTable
+
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget, LinkedMultiPlotWidget
+from pyqtgraph_scope_plots.stats_signals_table import StatsSignalsTable
 from .test_transforms import DATA
 
 

--- a/tests/test_table_search.py
+++ b/tests/test_table_search.py
@@ -23,8 +23,15 @@ from pyqtgraph_scope_plots.search_signals_table import SearchSignalsTable
 @pytest.fixture()
 def search_table(qtbot: QtBot) -> SearchSignalsTable:
     """Creates a signals plot with multiple data items"""
-    table = SearchSignalsTable(MultiPlotWidget())
-    table.set_data_items([("aaa", QColor("yellow")), ("abC", QColor("orange")), ("abd", QColor("blue"))])
+    plots = MultiPlotWidget()
+    table = SearchSignalsTable(plots)
+    plots.show_data_items(
+        [
+            ("aaa", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
+            ("abC", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
+            ("abd", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
+        ]
+    )
     qtbot.addWidget(table)
     table.show()
     qtbot.waitExposed(table)

--- a/tests/test_timeshift.py
+++ b/tests/test_timeshift.py
@@ -46,7 +46,6 @@ def timeshifts_plots(qtbot: QtBot) -> TimeshiftPlotWidget:
 
 def test_timeshift(qtbot: QtBot, timeshifts_plots: TimeshiftPlotWidget) -> None:
     timeshifts_table = TimeshiftSignalsTable(timeshifts_plots)
-    timeshifts_table._update()
     # test empty
     qtbot.waitUntil(lambda: timeshifts_plots._apply_timeshift("0", DATA).tolist() == [0.0, 0.1, 1.0, 2.0])
     timeshifts_plots.set_timeshift(["0"], 1)

--- a/tests/test_timeshift.py
+++ b/tests/test_timeshift.py
@@ -12,14 +12,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from typing import List, Tuple, Dict, Any, cast
-from unittest import mock
+from typing import cast
 
-import numpy as np
-import numpy.typing as npt
 import pytest
 from PySide6.QtGui import QColor
-from PySide6.QtWidgets import QInputDialog
 from pytestqt.qtbot import QtBot
 
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
@@ -28,13 +24,6 @@ from pyqtgraph_scope_plots.timeshift_signals_table import (
     TimeshiftDataStateModel,
     TimeshiftPlotWidget,
 )
-from pyqtgraph_scope_plots.transforms_signal_table import (
-    TransformsSignalsTable,
-    TransformsDataStateModel,
-    TransformsPlotWidget,
-)
-from pyqtgraph_scope_plots.util import not_none
-from .test_util import context_menu, menu_action_by_name
 from .test_transforms import DATA
 
 
@@ -57,6 +46,7 @@ def timeshifts_plots(qtbot: QtBot) -> TimeshiftPlotWidget:
 
 def test_timeshift(qtbot: QtBot, timeshifts_plots: TimeshiftPlotWidget) -> None:
     timeshifts_table = TimeshiftSignalsTable(timeshifts_plots)
+    timeshifts_table._update()
     # test empty
     qtbot.waitUntil(lambda: timeshifts_plots._apply_timeshift("0", DATA).tolist() == [0.0, 0.1, 1.0, 2.0])
     timeshifts_plots.set_timeshift(["0"], 1)

--- a/tests/test_timeshift.py
+++ b/tests/test_timeshift.py
@@ -1,0 +1,91 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from typing import List, Tuple, Dict, Any, cast
+from unittest import mock
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QInputDialog
+from pytestqt.qtbot import QtBot
+
+from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
+from pyqtgraph_scope_plots.timeshift_signals_table import (
+    TimeshiftSignalsTable,
+    TimeshiftDataStateModel,
+    TimeshiftPlotWidget,
+)
+from pyqtgraph_scope_plots.transforms_signal_table import (
+    TransformsSignalsTable,
+    TransformsDataStateModel,
+    TransformsPlotWidget,
+)
+from pyqtgraph_scope_plots.util import not_none
+from .test_util import context_menu, menu_action_by_name
+from .test_transforms import DATA
+
+
+@pytest.fixture()
+def timeshifts_plots(qtbot: QtBot) -> TimeshiftPlotWidget:
+    """Creates a signals plot with multiple data items"""
+    plots = TimeshiftPlotWidget()
+    plots.show_data_items(
+        [
+            ("0", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
+            ("1", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
+            ("2", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
+        ]
+    )
+    qtbot.addWidget(plots)
+    plots.show()
+    qtbot.waitExposed(plots)
+    return plots
+
+
+def test_timeshift(qtbot: QtBot, timeshifts_plots: TimeshiftPlotWidget) -> None:
+    timeshifts_table = TimeshiftSignalsTable(timeshifts_plots)
+    # test empty
+    qtbot.waitUntil(lambda: timeshifts_plots._apply_timeshift("0", DATA).tolist() == [0.0, 0.1, 1.0, 2.0])
+    timeshifts_plots.set_timeshift(["0"], 1)
+    qtbot.waitUntil(lambda: timeshifts_plots._apply_timeshift("0", DATA).tolist() == [1.0, 1.1, 2.0, 3.0])
+    assert timeshifts_table.item(0, timeshifts_table.COL_TIMESHIFT).text() == "1"
+    timeshifts_plots.set_timeshift(["0"], -0.5)  # test negative and noninteger
+    qtbot.waitUntil(lambda: timeshifts_plots._apply_timeshift("0", DATA).tolist() == [-0.5, -0.4, 0.5, 1.5])
+    assert timeshifts_table.item(0, timeshifts_table.COL_TIMESHIFT).text() == "-0.5"
+    timeshifts_plots.set_timeshift(["0"], 0)  # revert to empty
+    qtbot.waitUntil(lambda: timeshifts_plots._apply_timeshift("0", DATA).tolist() == [0.0, 0.1, 1.0, 2.0])
+    assert timeshifts_table.item(0, timeshifts_table.COL_TIMESHIFT).text() == ""
+
+
+def test_timeshift_save(qtbot: QtBot, timeshifts_plots: TimeshiftPlotWidget) -> None:
+    qtbot.waitUntil(
+        lambda: cast(TimeshiftDataStateModel, timeshifts_plots._dump_data_model(["0"]).data["0"]).timeshift == 0
+    )
+    timeshifts_plots.set_timeshift(["0"], -0.5)
+    qtbot.waitUntil(
+        lambda: cast(TimeshiftDataStateModel, timeshifts_plots._dump_data_model(["0"]).data["0"]).timeshift == -0.5
+    )
+
+
+def test_timeshift_load(qtbot: QtBot, timeshifts_plots: TimeshiftPlotWidget) -> None:
+    model = timeshifts_plots._dump_data_model(["0"])
+    cast(TimeshiftDataStateModel, model.data["0"]).timeshift = -0.5
+    timeshifts_plots._load_model(model)
+    qtbot.waitUntil(lambda: timeshifts_plots._apply_timeshift("0", DATA).tolist() == [-0.5, -0.4, 0.5, 1.5])
+
+    cast(TimeshiftDataStateModel, model.data["0"]).timeshift = 0
+    timeshifts_plots._load_model(model)
+    qtbot.waitUntil(lambda: timeshifts_plots._apply_timeshift("0", DATA).tolist() == [0.0, 0.1, 1.0, 2.0])

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -23,7 +23,6 @@ from PySide6.QtWidgets import QInputDialog
 from pytestqt.qtbot import QtBot
 
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
-from pyqtgraph_scope_plots.timeshift_signals_table import TimeshiftSignalsTable, TimeshiftDataStateModel
 from pyqtgraph_scope_plots.transforms_signal_table import (
     TransformsSignalsTable,
     TransformsDataStateModel,

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -100,6 +100,7 @@ def test_transform_multiple(qtbot: QtBot, transforms_plots: TransformsPlotWidget
 def test_transform_ui(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:
     """Basic test of transforms driven from the UI"""
     transforms_table = TransformsSignalsTable(transforms_plots)
+    transforms_table._update()
     target = transforms_table.visualItemRect(
         not_none(transforms_table.item(1, transforms_table.COL_TRANSFORM))
     ).center()
@@ -112,6 +113,7 @@ def test_transform_ui(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> N
 def test_transform_ui_syntaxerror(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:
     """Tests that syntax errors repeatedly prompt"""
     transforms_table = TransformsSignalsTable(transforms_plots)
+    transforms_table._update()
     target = transforms_table.visualItemRect(
         not_none(transforms_table.item(0, transforms_table.COL_TRANSFORM))
     ).center()
@@ -131,6 +133,7 @@ def test_transform_ui_syntaxerror(qtbot: QtBot, transforms_plots: TransformsPlot
 
 def test_transform_ui_error(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:
     transforms_table = TransformsSignalsTable(transforms_plots)
+    transforms_table._update()
     target = transforms_table.visualItemRect(
         not_none(transforms_table.item(0, transforms_table.COL_TRANSFORM))
     ).center()

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -33,23 +33,6 @@ from pyqtgraph_scope_plots.util import not_none
 from .test_util import context_menu, menu_action_by_name
 
 
-@pytest.fixture()
-def transforms_plots(qtbot: QtBot) -> TransformsPlotWidget:
-    """Creates a signals plot with multiple data items"""
-    plots = TransformsPlotWidget()
-    plots.show_data_items(
-        [
-            ("0", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
-            ("1", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
-            ("2", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
-        ]
-    )
-    qtbot.addWidget(plots)
-    plots.show()
-    qtbot.waitExposed(plots)
-    return plots
-
-
 def np_immutable(x: List[float]) -> npt.NDArray[np.float64]:
     """Creates a np.array with immutable set (writable=False)"""
     arr = np.array(x)
@@ -62,6 +45,24 @@ DATA: Dict[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = {
     "1": (np_immutable([0, 1, 2]), np_immutable([0.5, 0.25, 0.5])),
     "2": (np_immutable([0, 1, 2]), np_immutable([0.7, 0.6, 0.5])),
 }
+
+
+@pytest.fixture()
+def transforms_plots(qtbot: QtBot) -> TransformsPlotWidget:
+    """Creates a signals plot with multiple data items"""
+    plots = TransformsPlotWidget()
+    plots.show_data_items(
+        [
+            ("0", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
+            ("1", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
+            ("2", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
+        ]
+    )
+    plots.set_data(DATA)
+    qtbot.addWidget(plots)
+    plots.show()
+    qtbot.waitExposed(plots)
+    return plots
 
 
 def test_transform_empty(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:

--- a/tests/test_transforms_timeshift_table.py
+++ b/tests/test_transforms_timeshift_table.py
@@ -24,20 +24,30 @@ from pytestqt.qtbot import QtBot
 
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
 from pyqtgraph_scope_plots.timeshift_signals_table import TimeshiftSignalsTable, TimeshiftDataStateModel
-from pyqtgraph_scope_plots.transforms_signal_table import TransformsSignalsTable, TransformsDataStateModel
+from pyqtgraph_scope_plots.transforms_signal_table import (
+    TransformsSignalsTable,
+    TransformsDataStateModel,
+    TransformsPlotWidget,
+)
 from pyqtgraph_scope_plots.util import not_none
 from .test_util import context_menu, menu_action_by_name
 
 
 @pytest.fixture()
-def transforms_table(qtbot: QtBot) -> TransformsSignalsTable:
+def transforms_plots(qtbot: QtBot) -> TransformsPlotWidget:
     """Creates a signals plot with multiple data items"""
-    table = TransformsSignalsTable(MultiPlotWidget())
-    table.set_data_items([("0", QColor("yellow")), ("1", QColor("orange")), ("2", QColor("blue"))])
-    qtbot.addWidget(table)
-    table.show()
-    qtbot.waitExposed(table)
-    return table
+    plots = TransformsPlotWidget()
+    plots.show_data_items(
+        [
+            ("0", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
+            ("1", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
+            ("2", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
+        ]
+    )
+    qtbot.addWidget(plots)
+    plots.show()
+    qtbot.waitExposed(plots)
+    return plots
 
 
 @pytest.fixture()
@@ -65,52 +75,54 @@ DATA: Dict[str, Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]] = {
 }
 
 
-def test_transform_empty(qtbot: QtBot, transforms_table: TransformsSignalsTable) -> None:
+def test_transform_empty(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:
     """Tests empty transforms, should return the input"""
-    assert transforms_table.apply_transform("0", DATA).tolist() == [0.01, 1, 1, 0]
-    assert transforms_table.apply_transform("1", DATA).tolist() == [0.5, 0.25, 0.5]
-    assert transforms_table.apply_transform("2", DATA).tolist() == [0.7, 0.6, 0.5]
+    assert transforms_plots.apply_transform("0", DATA).tolist() == [0.01, 1, 1, 0]
+    assert transforms_plots.apply_transform("1", DATA).tolist() == [0.5, 0.25, 0.5]
+    assert transforms_plots.apply_transform("2", DATA).tolist() == [0.7, 0.6, 0.5]
 
 
-def test_transform_x(qtbot: QtBot, transforms_table: TransformsSignalsTable) -> None:
+def test_transform_x(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:
     """Tests transforms that only reference x"""
-    transforms_table.set_transform(["0"], "x + 1")
-    qtbot.waitUntil(lambda: transforms_table.apply_transform("0", DATA).tolist() == [1.01, 2, 2, 1])
+    transforms_plots.set_transform(["0"], "x + 1")
+    qtbot.waitUntil(lambda: transforms_plots.apply_transform("0", DATA).tolist() == [1.01, 2, 2, 1])
 
-    transforms_table.set_transform(["1"], "x * 2")
-    qtbot.waitUntil(lambda: transforms_table.apply_transform("1", DATA).tolist() == [1, 0.5, 1])
-    assert transforms_table.apply_transform("0", DATA).tolist() == [1.01, 2, 2, 1]  # should not affect 0
+    transforms_plots.set_transform(["1"], "x * 2")
+    qtbot.waitUntil(lambda: transforms_plots.apply_transform("1", DATA).tolist() == [1, 0.5, 1])
+    assert transforms_plots.apply_transform("0", DATA).tolist() == [1.01, 2, 2, 1]  # should not affect 0
 
-    transforms_table.set_transform(["0"], "")
-    qtbot.waitUntil(lambda: transforms_table.apply_transform("0", DATA).tolist() == [0.01, 1, 1, 0])
-    assert transforms_table.apply_transform("1", DATA).tolist() == [1, 0.5, 1]
+    transforms_plots.set_transform(["0"], "")
+    qtbot.waitUntil(lambda: transforms_plots.apply_transform("0", DATA).tolist() == [0.01, 1, 1, 0])
+    assert transforms_plots.apply_transform("1", DATA).tolist() == [1, 0.5, 1]
 
 
-def test_transform_multiple(qtbot: QtBot, transforms_table: TransformsSignalsTable) -> None:
+def test_transform_multiple(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:
     """Tests transforms that reference other data objects"""
-    transforms_table.set_transform(["1"], "x + data['2']")
-    qtbot.waitUntil(lambda: transforms_table.apply_transform("1", DATA).tolist() == [1.2, 0.85, 1])
+    transforms_plots.set_transform(["1"], "x + data['2']")
+    qtbot.waitUntil(lambda: transforms_plots.apply_transform("1", DATA).tolist() == [1.2, 0.85, 1])
 
-    transforms_table.set_transform(["1"], "x + data['0']")  # allow getting with longer data
-    qtbot.waitUntil(lambda: transforms_table.apply_transform("1", DATA).tolist() == [0.51, 1.25, 0.5])
+    transforms_plots.set_transform(["1"], "x + data['0']")  # allow getting with longer data
+    qtbot.waitUntil(lambda: transforms_plots.apply_transform("1", DATA).tolist() == [0.51, 1.25, 0.5])
 
-    transforms_table.set_transform(["0"], "x + data.get('1', 0)")  # test .get with missing values
-    qtbot.waitUntil(lambda: transforms_table.apply_transform("0", DATA).tolist() == [0.51, 1, 1.25, 0.5])
+    transforms_plots.set_transform(["0"], "x + data.get('1', 0)")  # test .get with missing values
+    qtbot.waitUntil(lambda: transforms_plots.apply_transform("0", DATA).tolist() == [0.51, 1, 1.25, 0.5])
 
 
-def test_transform_ui(qtbot: QtBot, transforms_table: TransformsSignalsTable) -> None:
+def test_transform_ui(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:
     """Basic test of transforms driven from the UI"""
+    transforms_table = TransformsSignalsTable(transforms_plots)
     target = transforms_table.visualItemRect(
         not_none(transforms_table.item(1, transforms_table.COL_TRANSFORM))
     ).center()
     with mock.patch.object(QInputDialog, "getText") as mock_input:  # allow getting with longer data
         mock_input.return_value = ("x + data['0']", True)
         menu_action_by_name(context_menu(qtbot, transforms_table, target), "set function").trigger()
-        qtbot.waitUntil(lambda: transforms_table.apply_transform("1", DATA).tolist() == [0.51, 1.25, 0.5])
+        qtbot.waitUntil(lambda: transforms_plots.apply_transform("1", DATA).tolist() == [0.51, 1.25, 0.5])
 
 
-def test_transform_ui_syntaxerror(qtbot: QtBot, transforms_table: TransformsSignalsTable) -> None:
+def test_transform_ui_syntaxerror(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:
     """Tests that syntax errors repeatedly prompt"""
+    transforms_table = TransformsSignalsTable(transforms_plots)
     target = transforms_table.visualItemRect(
         not_none(transforms_table.item(0, transforms_table.COL_TRANSFORM))
     ).center()
@@ -125,57 +137,58 @@ def test_transform_ui_syntaxerror(qtbot: QtBot, transforms_table: TransformsSign
 
         mock_input.side_effect = mock_value_update
         menu_action_by_name(context_menu(qtbot, transforms_table, target), "set function").trigger()
-        qtbot.waitUntil(lambda: transforms_table.apply_transform("0", DATA).tolist() == [1, 1, 1, 1])
+        qtbot.waitUntil(lambda: transforms_plots.apply_transform("0", DATA).tolist() == [1, 1, 1, 1])
 
 
-def test_transform_ui_error(qtbot: QtBot, transforms_table: TransformsSignalsTable) -> None:
+def test_transform_ui_error(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:
+    transforms_table = TransformsSignalsTable(transforms_plots)
     target = transforms_table.visualItemRect(
         not_none(transforms_table.item(0, transforms_table.COL_TRANSFORM))
     ).center()
     with mock.patch.object(QInputDialog, "getText") as mock_input:  # test error on missing values
         mock_input.return_value = ("ducks", True)
         menu_action_by_name(context_menu(qtbot, transforms_table, target), "set function").trigger()
-        qtbot.waitUntil(lambda: isinstance(transforms_table.apply_transform("0", DATA), Exception))  # must evaluate
+        qtbot.waitUntil(lambda: isinstance(transforms_plots.apply_transform("0", DATA), Exception))  # must evaluate
         qtbot.waitUntil(lambda: "NameNotDefined" in transforms_table.item(0, transforms_table.COL_TRANSFORM).text())
 
     with mock.patch.object(QInputDialog, "getText") as mock_input:  # test error on missing values
         mock_input.return_value = ("x + data['1']", True)
         menu_action_by_name(context_menu(qtbot, transforms_table, target), "set function").trigger()
-        qtbot.waitUntil(lambda: isinstance(transforms_table.apply_transform("0", DATA), Exception))  # must evaluate
+        qtbot.waitUntil(lambda: isinstance(transforms_plots.apply_transform("0", DATA), Exception))  # must evaluate
         qtbot.waitUntil(lambda: "KeyError" in transforms_table.item(0, transforms_table.COL_TRANSFORM).text())
 
     with mock.patch.object(QInputDialog, "getText") as mock_input:  # test error on missing values
         mock_input.return_value = ("'ducks'", True)
         menu_action_by_name(context_menu(qtbot, transforms_table, target), "set function").trigger()
-        qtbot.waitUntil(lambda: isinstance(transforms_table.apply_transform("0", DATA), Exception))  # must evaluate
+        qtbot.waitUntil(lambda: isinstance(transforms_plots.apply_transform("0", DATA), Exception))  # must evaluate
         qtbot.waitUntil(lambda: "TypeError" in transforms_table.item(0, transforms_table.COL_TRANSFORM).text())
 
 
-def test_transform_save(qtbot: QtBot, transforms_table: TransformsSignalsTable) -> None:
-    assert cast(TransformsDataStateModel, transforms_table._dump_data_model(["0", "1"]).data["0"]).transform == ""
-    assert cast(TransformsDataStateModel, transforms_table._dump_data_model(["0", "1"]).data["1"]).transform == ""
+def test_transform_save(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:
+    assert cast(TransformsDataStateModel, transforms_plots._dump_data_model(["0", "1"]).data["0"]).transform == ""
+    assert cast(TransformsDataStateModel, transforms_plots._dump_data_model(["0", "1"]).data["1"]).transform == ""
 
-    transforms_table.set_transform(["1"], "x + data['0']")  # allow getting with longer data
+    transforms_plots.set_transform(["1"], "x + data['0']")  # allow getting with longer data
     qtbot.waitUntil(
-        lambda: cast(TransformsDataStateModel, transforms_table._dump_data_model(["0", "1"]).data["1"]).transform
+        lambda: cast(TransformsDataStateModel, transforms_plots._dump_data_model(["0", "1"]).data["1"]).transform
         == "x + data['0']"
     )
     assert (
-        cast(TransformsDataStateModel, transforms_table._dump_data_model(["0", "1"]).data["0"]).transform == ""
+        cast(TransformsDataStateModel, transforms_plots._dump_data_model(["0", "1"]).data["0"]).transform == ""
     )  # unchanged
 
 
-def test_transform_load(qtbot: QtBot, transforms_table: TransformsSignalsTable) -> None:
+def test_transform_load(qtbot: QtBot, transforms_plots: TransformsPlotWidget) -> None:
     """Tests transforms that only reference x"""
-    model = transforms_table._dump_data_model(["0"])
+    model = transforms_plots._dump_data_model(["0"])
 
     cast(TransformsDataStateModel, model.data["0"]).transform = "x + 1"
-    transforms_table._load_model(model)
-    qtbot.waitUntil(lambda: transforms_table.apply_transform("0", DATA).tolist() == [1.01, 2, 2, 1])
+    transforms_plots._load_model(model)
+    qtbot.waitUntil(lambda: transforms_plots.apply_transform("0", DATA).tolist() == [1.01, 2, 2, 1])
 
     cast(TransformsDataStateModel, model.data["0"]).transform = ""
-    transforms_table._load_model(model)
-    qtbot.waitUntil(lambda: transforms_table.apply_transform("0", DATA).tolist() == [0.01, 1, 1, 0])
+    transforms_plots._load_model(model)
+    qtbot.waitUntil(lambda: transforms_plots.apply_transform("0", DATA).tolist() == [0.01, 1, 1, 0])
 
 
 def test_timeshift(qtbot: QtBot, timeshifts_table: TimeshiftSignalsTable) -> None:

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -20,7 +20,6 @@ from PySide6.QtGui import QColor
 from pytestqt.qtbot import QtBot
 
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
-from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
 from pyqtgraph_scope_plots.util import not_none
 from pyqtgraph_scope_plots.xy_plot import XyPlotWidget
 from pyqtgraph_scope_plots.xy_plot_refgeo import XyRefGeoModel

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -19,27 +19,27 @@ import pytest
 from PySide6.QtGui import QColor
 from pytestqt.qtbot import QtBot
 
-from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotWidget
+from pyqtgraph_scope_plots.plots_table_widget import PlotsTableWidget
 from pyqtgraph_scope_plots.util import not_none
-from pyqtgraph_scope_plots.xy_plot import XyPlotWidget, XyWindowModel
+from pyqtgraph_scope_plots.xy_plot import XyPlotWidget
 from pyqtgraph_scope_plots.xy_plot_refgeo import XyRefGeoModel
 from pyqtgraph_scope_plots.xy_plot_splitter import XyPlotSplitter
-from pyqtgraph_scope_plots.xy_plot_table import XyTableStateModel
+from pyqtgraph_scope_plots.xy_plot_table import XyTableStateModel, XyTable
 
 
 @pytest.fixture()
-def plot(qtbot: QtBot) -> PlotsTableWidget:
+def xy_table(qtbot: QtBot) -> XyTable:
     """Creates a signals plot with multiple data items"""
-    plot = PlotsTableWidget()
-    plot._set_data_items(
+    table = XyTable(MultiPlotWidget())
+    table._plots.show_data_items(
         [
             ("0", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
             ("1", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
             ("2", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
         ]
     )
-    plot._set_data(
+    table._plots.set_data(
         {
             "0": ([0, 1, 2], [0, 1, 2]),
             "1": ([0, 1, 2], [2, 1, 0]),
@@ -47,10 +47,10 @@ def plot(qtbot: QtBot) -> PlotsTableWidget:
             "X": ([0, 1, 4], [0, 1, 2]),  # not evenly spaced
         }
     )
-    qtbot.addWidget(plot)
-    plot.show()
-    qtbot.waitExposed(plot)
-    return plot
+    qtbot.addWidget(table)
+    table.show()
+    qtbot.waitExposed(table)
+    return table
 
 
 def test_correlated_indices() -> None:
@@ -86,19 +86,19 @@ def test_correlated_indices() -> None:
     assert XyPlotWidget._get_correlated_indices(np.array([0, 20, 30]), np.array([0, 10, 20, 30]), 0, 20) is None
 
 
-def test_xy_create_ui(qtbot: QtBot, plot: PlotsTableWidget) -> None:
+def test_xy_create_ui(qtbot: QtBot, xy_table: XyTable) -> None:
     # test that xy creation doesn't error out and follows the user order
-    plot._table.item(1, 0).setSelected(True)
-    plot._table.item(0, 0).setSelected(True)
-    xy_plot = cast(XyPlotSplitter, plot._table._on_create_xy())
+    xy_table.item(1, 0).setSelected(True)
+    xy_table.item(0, 0).setSelected(True)
+    xy_plot = cast(XyPlotSplitter, xy_table._on_create_xy())
     qtbot.waitSignal(xy_plot._xy_plots.sigXyDataItemsChanged)
     assert xy_plot is not None
     assert xy_plot._xy_plots._xys == [("1", "0")]
 
-    plot._table.clearSelection()
-    plot._table.item(0, 0).setSelected(True)
-    plot._table.item(1, 0).setSelected(True)
-    xy_plot = cast(XyPlotSplitter, plot._table._on_create_xy())
+    xy_table.clearSelection()
+    xy_table.item(0, 0).setSelected(True)
+    xy_table.item(1, 0).setSelected(True)
+    xy_plot = cast(XyPlotSplitter, xy_table._on_create_xy())
     qtbot.waitSignal(xy_plot._xy_plots.sigXyDataItemsChanged)
     assert xy_plot is not None
     assert xy_plot._xy_plots._xys == [("0", "1")]
@@ -106,16 +106,16 @@ def test_xy_create_ui(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     qtbot.wait(10)  # wait for rendering to happen
 
 
-def test_xy_close_cleanup(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    xy_plot = cast(XyPlotSplitter, plot._table.create_xy())
+def test_xy_close_cleanup(qtbot: QtBot, xy_table: XyTable) -> None:
+    xy_plot = cast(XyPlotSplitter, xy_table.create_xy())
     xy_plot.add_xy("0", "2")
-    qtbot.waitUntil(lambda: len(plot._table._xy_plots) > 0)
+    qtbot.waitUntil(lambda: len(xy_table._xy_plots) > 0)
     xy_plot.close()
-    qtbot.waitUntil(lambda: not plot._table._xy_plots)
+    qtbot.waitUntil(lambda: not xy_table._xy_plots)
 
 
-def test_xy_offset(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    xy_plot = cast(XyPlotSplitter, plot._table.create_xy())
+def test_xy_offset(qtbot: QtBot, xy_table: XyTable) -> None:
+    xy_plot = cast(XyPlotSplitter, xy_table.create_xy())
     xy_plot.add_xy("0", "2")
     xy_plot.add_xy("2", "0")
     assert xy_plot._xy_plots._xys == [("0", "2"), ("2", "0")]
@@ -123,26 +123,26 @@ def test_xy_offset(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     qtbot.wait(10)  # wait for rendering to happen to ensure it doesn't error
 
 
-def test_xy_save(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    xy_plot = plot._table.create_xy()
+def test_xy_save(qtbot: QtBot, xy_table: XyTable) -> None:
+    xy_plot = xy_table.create_xy()
     xy_plot.add_xy("0", "1")
     xy_plot.add_xy("1", "0")
-    qtbot.waitUntil(lambda: len(not_none(cast(XyTableStateModel, plot._table._dump_data_model([])).xy_windows)) == 1)
-    model = cast(XyTableStateModel, plot._table._dump_data_model([]))
+    qtbot.waitUntil(lambda: len(not_none(cast(XyTableStateModel, xy_table._dump_data_model([])).xy_windows)) == 1)
+    model = cast(XyTableStateModel, xy_table._dump_data_model([]))
     assert not_none(model.xy_windows)[0].xy_data_items == [("0", "1"), ("1", "0")]
 
 
-def test_xy_load(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    model = cast(XyTableStateModel, plot._table._dump_data_model([]))
+def test_xy_load(qtbot: QtBot, xy_table: XyTable) -> None:
+    model = cast(XyTableStateModel, xy_table._dump_data_model([]))
 
     model.xy_windows = [XyRefGeoModel(xy_data_items=[("1", "0")])]
-    plot._table._load_model(model)
-    qtbot.waitUntil(lambda: len(plot._table._xy_plots) == 1)
-    assert cast(XyPlotSplitter, plot._table._xy_plots[0])._xy_plots._xys == [("1", "0")]
+    xy_table._load_model(model)
+    qtbot.waitUntil(lambda: len(xy_table._xy_plots) == 1)
+    assert cast(XyPlotSplitter, xy_table._xy_plots[0])._xy_plots._xys == [("1", "0")]
 
 
-def test_xy_table(qtbot: QtBot, plot: PlotsTableWidget) -> None:
-    xy_plot = cast(XyPlotSplitter, plot._table.create_xy())
+def test_xy_table(qtbot: QtBot, xy_table: XyTable) -> None:
+    xy_plot = cast(XyPlotSplitter, xy_table.create_xy())
     xy_plot.add_xy("0", "1")
     qtbot.waitUntil(lambda: xy_plot._table.rowCount() == 1)
     assert xy_plot._table.item(0, 0).text() == "0"


### PR DESCRIPTION
Previously, the signals table needed the top-level splitter to coordinate between it and the plots. This makes the signal table operate directly on the plots, eliminating the need for top-level boilerplate.

This is a hefty refactor. A major part of this is splitting files.

For widgets where the main logic was in the table (like timeshift or transforms), moves the main logic into the plots and exposes an API for the UI logic in the table. Some other logic previously at the top-level (like creating immutable arrays) is moved into the plots.

Other:
- Allows _PLOT_TYPE / _TABLE_TYPE to specify the plot type instead of requiring the more verbose _make_plot
- Add stats tests
- Adds base infrastructure for transforms in MultiPlotWidget, as something between data-in and data-rendered. This facility accommodates function-transforms and timeshifts.
- Allow _make_controls => None in top-level
