### PR TITLE
Legends on XY plots

### DIFF
--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -70,6 +70,7 @@ __all__ = [
     "TransformsSignalsTable",
     "VisibilityPlotWidget",
     "VisibilityToggleSignalsTable",
+    "LegendPlotWidget",
     "PlotsTableWidget",
     "XyPlotWidget",
     "XyDragDroppable",

--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -28,6 +28,7 @@ from .color_signals_table import ColorPickerPlotWidget, ColorPickerSignalsTable
 from .timeshift_signals_table import TimeshiftPlotWidget, TimeshiftSignalsTable
 from .transforms_signal_table import TransformsPlotWidget, TransformsSignalsTable
 from .visibility_toggle_table import VisibilityPlotWidget, VisibilityToggleSignalsTable
+from .legend_plot_widget import LegendPlotWidget
 from .plots_table_widget import PlotsTableWidget
 
 # xy and mixins
@@ -43,6 +44,7 @@ from .xy_plot_refgeo import RefGeoXyPlotWidget, RefGeoXyPlotTable
 from .xy_plot_visibility import VisibilityXyPlotWidget, VisibilityXyPlotTable
 from .xy_plot_splitter import XyPlotSplitter
 from .xy_plot_table import XyTable
+from .xy_plot_legends import XyTableLegends
 
 
 __all__ = [
@@ -81,4 +83,5 @@ __all__ = [
     "VisibilityXyPlotTable",
     "XyPlotSplitter",
     "XyTable",
+    "XyTableLegends",
 ]

--- a/pyqtgraph_scope_plots/animation_plot_table_widget.py
+++ b/pyqtgraph_scope_plots/animation_plot_table_widget.py
@@ -62,8 +62,7 @@ class AnimationPlotsTableWidget(PlotsTableWidget):
         capture_windows: List[QWidget] = [self._plots]
         if isinstance(self._table, XyTable):
             for widget in self._table._xy_plots:
-                assert isinstance(widget, QWidget)
-                capture_windows.append(widget)
+                capture_windows.append(widget.get_plot_widget())
 
         images = []
         for i in range(frames_count):

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -38,6 +38,8 @@ from PySide6.QtWidgets import (
 )
 from pydantic import BaseModel
 
+from ..legend_plot_widget import LegendPlotWidget
+from ..xy_plot_legends import XyTableLegends
 from ..xy_plot_visibility import VisibilityXyPlotWidget, VisibilityXyPlotTable
 from ..visibility_toggle_table import VisibilityToggleSignalsTable, VisibilityPlotWidget
 from ..animation_plot_table_widget import AnimationPlotsTableWidget
@@ -85,20 +87,18 @@ class FullXySplitter(XyPlotSplitter):
 
 
 class FullPlots(
-    VisibilityPlotWidget, ColorPickerPlotWidget, TimeshiftPlotWidget, TransformsPlotWidget, PlotsTableWidget.Plots
+    LegendPlotWidget,
+    VisibilityPlotWidget,
+    ColorPickerPlotWidget,
+    TimeshiftPlotWidget,
+    TransformsPlotWidget,
+    PlotsTableWidget.Plots,
 ):
     """Adds legend add functionality"""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._thickness: float = 1
-        self._show_legend: bool = False
         super().__init__(*args, **kwargs)
-
-    def _init_plot_item(self, plot_item: pg.PlotItem) -> pg.PlotItem:
-        plot_item = super()._init_plot_item(plot_item)
-        if self._show_legend:
-            plot_item.addLegend()
-        return plot_item
 
     def _update_plots(self) -> None:
         super()._update_plots()
@@ -111,15 +111,10 @@ class FullPlots(
         self._thickness = thickness
         self._update_plots()
 
-    def show_legends(self) -> None:
-        self._show_legend = True
-        for plot_item, _ in self._plot_item_data.items():
-            plot_item.addLegend()
-        self._update_plots()
-
 
 class FullSignalsTable(
     VisibilityToggleSignalsTable,
+    XyTableLegends,
     XyTable,
     ColorPickerSignalsTable,
     TimeshiftSignalsTable,
@@ -202,8 +197,10 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
 
     def _on_legend_checked(self) -> None:
         assert isinstance(self._plots, FullPlots)
+        assert isinstance(self._table, FullSignalsTable)
         self._legend_action.setDisabled(True)  # pyqtgraph doesn't support deleting legends
         self._plots.show_legends()
+        self._table.show_legends()
 
     def _on_line_width_action(self) -> None:
         assert isinstance(self._plots, FullPlots)

--- a/pyqtgraph_scope_plots/legend_plot_widget.py
+++ b/pyqtgraph_scope_plots/legend_plot_widget.py
@@ -1,3 +1,16 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
 from typing import Any, Optional
 import pyqtgraph as pg
 from pydantic import BaseModel

--- a/pyqtgraph_scope_plots/legend_plot_widget.py
+++ b/pyqtgraph_scope_plots/legend_plot_widget.py
@@ -1,16 +1,34 @@
-from typing import Any
+from typing import Any, Optional
 import pyqtgraph as pg
+from pydantic import BaseModel
 
-from pyqtgraph_scope_plots import MultiPlotWidget
+from pyqtgraph_scope_plots import MultiPlotWidget, HasSaveLoadDataConfig
 
 
-class LegendPlotWidget(MultiPlotWidget):
+class ShowLegendsStateModel(BaseModel):
+    show_legends: Optional[bool] = None
+
+
+class LegendPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
     """Adds a show-legend API. Once the legend is shown, it cannot be hidden again, since pyqtgraph
     does not provide those APIs"""
+
+    _MODEL_BASES = [ShowLegendsStateModel]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._show_legend: bool = False
         super().__init__(*args, **kwargs)
+
+    def _write_model(self, model: BaseModel) -> None:
+        super()._write_model(model)
+        assert isinstance(model, ShowLegendsStateModel)
+        model.show_legends = self._show_legend
+
+    def _load_model(self, model: BaseModel) -> None:
+        super()._load_model(model)
+        assert isinstance(model, ShowLegendsStateModel)
+        if model.show_legends == True and not self._show_legend:
+            self.show_legends()
 
     def _init_plot_item(self, plot_item: pg.PlotItem) -> pg.PlotItem:
         plot_item = super()._init_plot_item(plot_item)

--- a/pyqtgraph_scope_plots/legend_plot_widget.py
+++ b/pyqtgraph_scope_plots/legend_plot_widget.py
@@ -1,0 +1,25 @@
+from typing import Any
+import pyqtgraph as pg
+
+from pyqtgraph_scope_plots import MultiPlotWidget
+
+
+class LegendPlotWidget(MultiPlotWidget):
+    """Adds a show-legend API. Once the legend is shown, it cannot be hidden again, since pyqtgraph
+    does not provide those APIs"""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._show_legend: bool = False
+        super().__init__(*args, **kwargs)
+
+    def _init_plot_item(self, plot_item: pg.PlotItem) -> pg.PlotItem:
+        plot_item = super()._init_plot_item(plot_item)
+        if self._show_legend:
+            plot_item.addLegend()
+        return plot_item
+
+    def show_legends(self) -> None:
+        self._show_legend = True
+        for plot_item, _ in self._plot_item_data.items():
+            plot_item.addLegend()
+        self._update_plots()

--- a/pyqtgraph_scope_plots/legend_plot_widget.py
+++ b/pyqtgraph_scope_plots/legend_plot_widget.py
@@ -11,25 +11,24 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+from abc import abstractmethod
 from typing import Any, Optional
 import pyqtgraph as pg
 from pydantic import BaseModel
 
-from pyqtgraph_scope_plots import MultiPlotWidget, HasSaveLoadDataConfig
+from .util import HasSaveLoadDataConfig
+from .multi_plot_widget import MultiPlotWidget
 
 
 class ShowLegendsStateModel(BaseModel):
     show_legends: Optional[bool] = None
 
 
-class LegendPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
-    """Adds a show-legend API. Once the legend is shown, it cannot be hidden again, since pyqtgraph
-    does not provide those APIs"""
-
+class BaseLegendSaveLoad(HasSaveLoadDataConfig):
     _MODEL_BASES = [ShowLegendsStateModel]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._show_legend: bool = False
+        self._show_legend: bool = False  # inspect this to show legend on plot creation
         super().__init__(*args, **kwargs)
 
     def _write_model(self, model: BaseModel) -> None:
@@ -42,6 +41,16 @@ class LegendPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
         assert isinstance(model, ShowLegendsStateModel)
         if model.show_legends == True and not self._show_legend:
             self.show_legends()
+
+    @abstractmethod
+    def show_legends(self) -> None:
+        """Implement me to show legends in response to some action"""
+        ...
+
+
+class LegendPlotWidget(BaseLegendSaveLoad, MultiPlotWidget):
+    """Adds a show-legend API. Once the legend is shown, it cannot be hidden again, since pyqtgraph
+    does not provide those APIs"""
 
     def _init_plot_item(self, plot_item: pg.PlotItem) -> pg.PlotItem:
         plot_item = super()._init_plot_item(plot_item)

--- a/pyqtgraph_scope_plots/util/save_restore_model.py
+++ b/pyqtgraph_scope_plots/util/save_restore_model.py
@@ -12,12 +12,12 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from typing import List, Type, Dict, Iterable, Optional, Set, TypeVar
+from typing import List, Type, Dict, Iterable, Optional, Set, TypeVar, Hashable
 
 import pydantic
 from pydantic import BaseModel
 
-DedupListType = TypeVar("DedupListType")
+DedupListType = TypeVar("DedupListType", bound=Hashable)
 
 
 class HasSaveLoadConfig:

--- a/pyqtgraph_scope_plots/xy_plot_legends.py
+++ b/pyqtgraph_scope_plots/xy_plot_legends.py
@@ -11,36 +11,17 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-from typing import Any, cast
+from typing import cast
 
 import pyqtgraph as pg
-from pydantic import BaseModel
 
-from .util import HasSaveLoadDataConfig
-from .legend_plot_widget import ShowLegendsStateModel
-from .xy_plot_table import XyTable
+from .legend_plot_widget import BaseLegendSaveLoad
 from .xy_plot import BaseXyPlot
+from .xy_plot_table import XyTable
 
 
-class XyTableLegends(XyTable, HasSaveLoadDataConfig):
+class XyTableLegends(BaseLegendSaveLoad, XyTable):
     """Mixin into XyTable that allows legends to be shown."""
-
-    _MODEL_BASES = [ShowLegendsStateModel]
-
-    def __init__(self, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
-        self._show_legend: bool = False
-
-    def _write_model(self, model: BaseModel) -> None:
-        super()._write_model(model)
-        assert isinstance(model, ShowLegendsStateModel)
-        model.show_legends = self._show_legend
-
-    def _load_model(self, model: BaseModel) -> None:
-        super()._load_model(model)
-        assert isinstance(model, ShowLegendsStateModel)
-        if model.show_legends == True and not self._show_legend:
-            self.show_legends()
 
     def show_legends(self) -> None:
         self._show_legend = True

--- a/pyqtgraph_scope_plots/xy_plot_legends.py
+++ b/pyqtgraph_scope_plots/xy_plot_legends.py
@@ -16,7 +16,7 @@ from typing import Any, cast
 import pyqtgraph as pg
 from pydantic import BaseModel
 
-from . import HasSaveLoadDataConfig
+from .util import HasSaveLoadDataConfig
 from .legend_plot_widget import ShowLegendsStateModel
 from .xy_plot_table import XyTable
 from .xy_plot import BaseXyPlot

--- a/pyqtgraph_scope_plots/xy_plot_legends.py
+++ b/pyqtgraph_scope_plots/xy_plot_legends.py
@@ -14,17 +14,33 @@
 from typing import Any, cast
 
 import pyqtgraph as pg
+from pydantic import BaseModel
 
+from . import HasSaveLoadDataConfig
+from .legend_plot_widget import ShowLegendsStateModel
 from .xy_plot_table import XyTable
 from .xy_plot import BaseXyPlot
 
 
-class XyTableLegends(XyTable):
+class XyTableLegends(XyTable, HasSaveLoadDataConfig):
     """Mixin into XyTable that allows legends to be shown."""
+
+    _MODEL_BASES = [ShowLegendsStateModel]
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self._show_legend: bool = False
+
+    def _write_model(self, model: BaseModel) -> None:
+        super()._write_model(model)
+        assert isinstance(model, ShowLegendsStateModel)
+        model.show_legends = self._show_legend
+
+    def _load_model(self, model: BaseModel) -> None:
+        super()._load_model(model)
+        assert isinstance(model, ShowLegendsStateModel)
+        if model.show_legends == True and not self._show_legend:
+            self.show_legends()
 
     def show_legends(self) -> None:
         self._show_legend = True

--- a/pyqtgraph_scope_plots/xy_plot_legends.py
+++ b/pyqtgraph_scope_plots/xy_plot_legends.py
@@ -1,0 +1,39 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+from typing import Any, cast
+
+import pyqtgraph as pg
+
+from .xy_plot_table import XyTable
+from .xy_plot import BaseXyPlot
+
+
+class XyTableLegends(XyTable):
+    """Mixin into XyTable that allows legends to be shown."""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._show_legend: bool = False
+
+    def show_legends(self) -> None:
+        self._show_legend = True
+        for xy_plot in self._xy_plots:
+            cast(pg.PlotItem, xy_plot.get_plot_widget().getPlotItem()).addLegend()
+            xy_plot.get_plot_widget()._update()
+
+    def create_xy(self) -> BaseXyPlot:
+        xy_plot = super().create_xy()
+        if self._show_legend:
+            cast(pg.PlotItem, xy_plot.get_plot_widget().getPlotItem()).addLegend()
+        return xy_plot

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -162,7 +162,7 @@ class RefGeoXyPlotTable(DeleteableXyPlotTable, ContextMenuXyPlotTable, XyPlotTab
             self.setSpan(self._row_offset_refgeo + row, self.COL_X_NAME, 1, 2)
 
     def _on_refgeo_double_click(self, row: int, col: int) -> None:
-        if row >= self._row_offset_refgeo and col == 0:
+        if row >= self._row_offset_refgeo and col == self.COL_X_NAME:
             self._on_set_refgeo(row - self._row_offset_refgeo)
 
     def _on_set_refgeo(self, index: Optional[int] = None) -> None:

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -17,6 +17,7 @@ from PySide6 import QtGui
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QSplitter
 from pydantic import BaseModel
+import pyqtgraph as pg
 
 from .multi_plot_widget import MultiPlotWidget
 from .xy_plot import BaseXyPlot, XyPlotWidget, XyPlotTable
@@ -48,6 +49,12 @@ class XyPlotSplitter(BaseXyPlot, QSplitter):
 
     def add_xy(self, x_name: str, y_name: str) -> None:
         self._xy_plots.add_xy(x_name, y_name)
+
+    def remove_xy(self, x_name: str, y_name: str) -> None:
+        self._xy_plots.remove_xy(x_name, y_name)
+
+    def get_plot_widget(self) -> XyPlotWidget:
+        return self._xy_plots
 
     @classmethod
     def _create_skeleton_model_type(cls) -> Type[BaseModel]:

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -17,7 +17,6 @@ from PySide6 import QtGui
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QSplitter
 from pydantic import BaseModel
-import pyqtgraph as pg
 
 from .multi_plot_widget import MultiPlotWidget
 from .xy_plot import BaseXyPlot, XyPlotWidget, XyPlotTable

--- a/pyqtgraph_scope_plots/xy_plot_table.py
+++ b/pyqtgraph_scope_plots/xy_plot_table.py
@@ -34,7 +34,7 @@ class XyTable(DraggableSignalsTable, ContextMenuSignalsTable, HasSaveLoadDataCon
     _XY_PLOT_TYPE: Type[BaseXyPlot] = XyPlotSplitter
 
     @classmethod
-    def _create_class_model_bases(cls) -> Optional[List[Type[BaseModel]]]:
+    def _create_class_model_bases(cls) -> List[Type[BaseModel]]:
         return [
             create_model(
                 "XyTableStateModel",

--- a/tests/test_save_restore_model_infra.py
+++ b/tests/test_save_restore_model_infra.py
@@ -43,7 +43,7 @@ class SaveRestoreSub(HasSaveLoadDataConfig):
     _MODEL_BASES = [BaseModelSub1]
 
     @classmethod
-    def _create_class_model_bases(cls) -> Optional[List[Type[BaseModel]]]:
+    def _create_class_model_bases(cls) -> List[Type[BaseModel]]:
         return [BaseModelSub2]
 
     _DATA_MODEL_BASES = [DataModelSub1, DataModelSub2]


### PR DESCRIPTION
Move the show-legends functionality from the CSV into a mixin. Add a show-legends mixin for the XY table to show legends on XY plots. Legends state is also saved.

Other changes:
- animation generation ignores the XY table now
- add deduplication for model bases, allowing (here) multiple mixins to share the same legends state model
- names xy plots so legends work
- fix reference geometry column for clicks