### PR TITLE
Improved XY reference geometry

### DIFF
--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -99,10 +99,6 @@ class RefGeoXyPlotWidget(XyPlotWidget, HasSaveLoadConfig):
             except Exception as e:
                 print(f"failed to restore ref geometry fn {ref_geo.expr}: {e}")  # TODO better logging
 
-        # bulk update
-        self._update()
-        self.sigXyDataItemsChanged.emit()
-
     def set_ref_geometry_fn(
         self,
         expr_str: str,

--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -119,7 +119,7 @@ class RefGeoXyPlotWidget(XyPlotWidget, HasSaveLoadConfig):
             }
             try:
                 xs, ys = self._simpleeval.eval(refgeo_expr, refgeo_parsed)
-                curve = pg.PlotCurveItem(x=xs, y=ys)
+                curve = pg.PlotCurveItem(x=xs, y=ys, name=refgeo_expr)
                 self.addItem(curve)
                 self._refgeo_errs.append(None)
             except Exception as e:

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -144,16 +144,22 @@ def test_refgeo_save(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
     model_ref_geo = not_none(cast(XyRefGeoModel, plot._dump_model()).ref_geo)
     assert len(model_ref_geo) == 1
     assert model_ref_geo[0].expr == "([-1, 1], [-1, -1])"
+    assert model_ref_geo[0].color == "#ffffff"  # default
+
+    plot.set_ref_geometry_fn("([-1, 1], [-1, -1])", color=QColor("yellow"), index=0)
+    model_ref_geo = not_none(cast(XyRefGeoModel, plot._dump_model()).ref_geo)
+    assert model_ref_geo[0].color == "#ffff00"
 
 
 def test_refgeo_load(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
     table = RefGeoXyPlotTable(plot._plots, plot)
     model = cast(XyRefGeoModel, plot._dump_model())
 
-    model.ref_geo = [XyRefGeoData(expr="([-1, 1], [-1, -1])")]
+    model.ref_geo = [XyRefGeoData(expr="([-1, 1], [-1, -1])", color="yellow")]
     plot._load_model(model)
     qtbot.waitUntil(lambda: table.rowCount() == 1)
     assert table.item(0, 0).text() == "([-1, 1], [-1, -1])"
+    assert table.item(0, 0).foreground().color() == QColor("yellow")
 
     model.ref_geo = []
     plot._load_model(model)

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -169,12 +169,16 @@ def test_refgeo_load(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
 
     model.ref_geo = [XyRefGeoData(expr="([-1, 1], [-1, -1])", color="yellow")]
     plot._load_model(model)
+    plot._update()
+    plot.sigXyDataItemsChanged.emit()
     qtbot.waitUntil(lambda: table.rowCount() == 1)
     assert table.item(0, table.COL_X_NAME).text() == "([-1, 1], [-1, -1])"
     assert table.item(0, table.COL_X_NAME).foreground().color() == QColor("yellow")
 
     model.ref_geo = []
     plot._load_model(model)
+    plot._update()
+    plot.sigXyDataItemsChanged.emit()
     qtbot.waitUntil(lambda: table.rowCount() == 0)
 
 
@@ -214,6 +218,8 @@ def test_refgeo_visibility_load(qtbot: QtBot, visibility_plot: RefGeoWithVisibil
 
     model.ref_geo = [XyRefGeoData(expr="([-1, 1], [-1, -1])", hidden=True)]
     visibility_plot._load_model(model)
+    visibility_plot._update()
+    visibility_plot.sigXyDataItemsChanged.emit()
     qtbot.waitUntil(lambda: table.rowCount() == 1)
     assert table.item(0, table.COL_X_NAME).text() == "([-1, 1], [-1, -1])"
     assert table.item(0, table.COL_VISIBILITY).checkState() == Qt.CheckState.Unchecked

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -21,7 +21,8 @@ from PySide6.QtGui import QColor, Qt
 from pytestqt.qtbot import QtBot
 
 from pyqtgraph_scope_plots import MultiPlotWidget, LinkedMultiPlotWidget, RefGeoXyPlotWidget, RefGeoXyPlotTable
-from pyqtgraph_scope_plots.xy_plot_refgeo import XyRefGeoModel
+from pyqtgraph_scope_plots.util import not_none
+from pyqtgraph_scope_plots.xy_plot_refgeo import XyRefGeoModel, XyRefGeoData
 
 
 @pytest.fixture()
@@ -137,17 +138,19 @@ def test_table_err(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
 
 
 def test_refgeo_save(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
-    qtbot.waitUntil(lambda: cast(XyRefGeoModel, plot._dump_model()).ref_geo == [])
+    assert cast(XyRefGeoModel, plot._dump_model()).ref_geo == []
 
     plot.set_ref_geometry_fn("([-1, 1], [-1, -1])")
-    qtbot.waitUntil(lambda: cast(XyRefGeoModel, plot._dump_model()).ref_geo == ["([-1, 1], [-1, -1])"])
+    model_ref_geo = not_none(cast(XyRefGeoModel, plot._dump_model()).ref_geo)
+    assert len(model_ref_geo) == 1
+    assert model_ref_geo[0].expr == "([-1, 1], [-1, -1])"
 
 
 def test_refgeo_load(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
     table = RefGeoXyPlotTable(plot._plots, plot)
     model = cast(XyRefGeoModel, plot._dump_model())
 
-    model.ref_geo = ["([-1, 1], [-1, -1])"]
+    model.ref_geo = [XyRefGeoData(expr="([-1, 1], [-1, -1])")]
     plot._load_model(model)
     qtbot.waitUntil(lambda: table.rowCount() == 1)
     assert table.item(0, 0).text() == "([-1, 1], [-1, -1])"

--- a/tests/test_xy_plot_refgeo.py
+++ b/tests/test_xy_plot_refgeo.py
@@ -88,21 +88,21 @@ def test_table(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
     table = RefGeoXyPlotTable(plot._plots, plot)
     plot.set_ref_geometry_fn("([-1, 1], [-1, -1])")
     qtbot.waitUntil(lambda: table.rowCount() == 1)
-    assert table.item(0, 0).text() == "([-1, 1], [-1, -1])"
+    assert table.item(0, table.COL_X_NAME).text() == "([-1, 1], [-1, -1])"
 
     plot.set_ref_geometry_fn("([-1, 2], [-1, -1])")  # addition
     qtbot.waitUntil(lambda: table.rowCount() == 2)
-    assert table.item(0, 0).text() == "([-1, 1], [-1, -1])"
-    assert table.item(1, 0).text() == "([-1, 2], [-1, -1])"
+    assert table.item(0, table.COL_X_NAME).text() == "([-1, 1], [-1, -1])"
+    assert table.item(1, table.COL_X_NAME).text() == "([-1, 2], [-1, -1])"
 
     plot.set_ref_geometry_fn("([-1, 0], [-1, -1])", 1)  # replacement
     qtbot.waitUntil(lambda: table.rowCount() == 2)
-    assert table.item(0, 0).text() == "([-1, 1], [-1, -1])"
-    assert table.item(1, 0).text() == "([-1, 0], [-1, -1])"
+    assert table.item(0, table.COL_X_NAME).text() == "([-1, 1], [-1, -1])"
+    assert table.item(1, table.COL_X_NAME).text() == "([-1, 0], [-1, -1])"
 
     plot.set_ref_geometry_fn("", 0)  # deletion
     qtbot.waitUntil(lambda: table.rowCount() == 1)
-    assert table.item(0, 0).text() == "([-1, 0], [-1, -1])"
+    assert table.item(0, table.COL_X_NAME).text() == "([-1, 0], [-1, -1])"
 
 
 def test_table_deletion(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
@@ -158,8 +158,8 @@ def test_refgeo_load(qtbot: QtBot, plot: RefGeoXyPlotWidget) -> None:
     model.ref_geo = [XyRefGeoData(expr="([-1, 1], [-1, -1])", color="yellow")]
     plot._load_model(model)
     qtbot.waitUntil(lambda: table.rowCount() == 1)
-    assert table.item(0, 0).text() == "([-1, 1], [-1, -1])"
-    assert table.item(0, 0).foreground().color() == QColor("yellow")
+    assert table.item(0, table.COL_X_NAME).text() == "([-1, 1], [-1, -1])"
+    assert table.item(0, table.COL_X_NAME).foreground().color() == QColor("yellow")
 
     model.ref_geo = []
     plot._load_model(model)


### PR DESCRIPTION
- Changes data schema for XY reference geometry, with a conversion
- Support color on reference geometry
- Add name to reference geometry, allowing it to show up on legend
- Support visibility toggle on reference geometry, if also using the xy-visibility-table
- Thickness on CSV viewer now updates XY plots
- Eliminate an unnecessary update after load on ref-geo

Implementation notes
- Reference geometry functions store color and hidden state. Hidden state is there (instead of a separate hidden_refgeos structure) since it should track the 'unique' reference geometry item, instead of by index or function text
- Change refgeo errors to store either the curve or errors
