### PR TITLE
Live stats on updating data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["tests.*"]
-disable_error_code = ["union-attr"]
+disable_error_code = ["union-attr", "no-untyped-call"]
 
 [tool.pytest]
 qt_api = "pyside6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pyqtgraph-scope-plots"
 description = "Scope like plot utilities for pyqtgraph"
 readme = "README.md"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
     { name = "Richard Lin", email = "richardlin@enphaseenergy.com" }
 ]

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -92,9 +92,9 @@ class HasRegionSignalsTable(SignalsTable):
         Expands the region slightly to account for floating point imprecision"""
         ROUNDING_FACTOR = 2e-7
 
-        region = (region[0] - region[0] * ROUNDING_FACTOR, region[1] + region[1] * ROUNDING_FACTOR)
-        low_index = bisect.bisect_left(ts, region[0])  # inclusive
-        high_index = bisect.bisect_right(ts, region[1])  # exclusive
+        tolerance = (region[1] - region[0]) * ROUNDING_FACTOR
+        low_index = bisect.bisect_left(list(ts), region[0] - tolerance)  # inclusive
+        high_index = bisect.bisect_right(list(ts), region[1] + tolerance)  # exclusive
         if low_index >= high_index:  # empty set
             return None, None
         else:

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -93,8 +93,8 @@ class HasRegionSignalsTable(SignalsTable):
         ROUNDING_FACTOR = 2e-7
 
         tolerance = (region[1] - region[0]) * ROUNDING_FACTOR
-        low_index = bisect.bisect_left(list(ts), region[0] - tolerance)  # inclusive
-        high_index = bisect.bisect_right(list(ts), region[1] + tolerance)  # exclusive
+        low_index = bisect.bisect_left(ts, region[0] - tolerance)  # inclusive
+        high_index = bisect.bisect_right(ts, region[1] + tolerance)  # exclusive
         if low_index >= high_index:  # empty set
             return None, None
         else:

--- a/pyqtgraph_scope_plots/stats_signals_table.py
+++ b/pyqtgraph_scope_plots/stats_signals_table.py
@@ -56,7 +56,7 @@ class StatsSignalsTable(HasRegionSignalsTable):
         request = Signal()
         update = Signal(object, object, object)  # input array, region, {stat (by offset col) -> value}
 
-        def __init__(self):
+        def __init__(self) -> None:
             super().__init__()
             self._request_mutex = QMutex()
             self._request_data: List[
@@ -164,7 +164,7 @@ class StatsSignalsTable(HasRegionSignalsTable):
         self._stats_worker.update.connect(self._on_stats_updated)
 
     @staticmethod
-    def _on_destroyed(thread_object: QThread):
+    def _on_destroyed(thread_object: QThread) -> None:
         thread_object.quit()
         thread_object.wait()
 

--- a/pyqtgraph_scope_plots/stats_signals_table.py
+++ b/pyqtgraph_scope_plots/stats_signals_table.py
@@ -74,7 +74,8 @@ class StatsSignalsTable(HasRegionSignalsTable):
             region: Tuple[float, float],
             delay_ms: int,
         ) -> None:
-            """Called from the main thread to update the task."""
+            """Called from the main thread to request a stats calculation be run on the input data set
+            over the input region, and with an optional debouncing delay before starting."""
             with QMutexLocker(self._request_mutex):
                 self._request_data = data
                 self._request_region = region

--- a/pyqtgraph_scope_plots/stats_signals_table.py
+++ b/pyqtgraph_scope_plots/stats_signals_table.py
@@ -20,7 +20,7 @@ from typing import Dict, Tuple, List, Any
 
 import numpy as np
 import numpy.typing as npt
-from PySide6.QtCore import Signal, QObject, QThread, QMutex, QMutexLocker, Qt
+from PySide6.QtCore import Signal, QObject, QThread, QMutex, QMutexLocker
 from PySide6.QtWidgets import QTableWidgetItem
 
 from .signals_table import HasRegionSignalsTable


### PR DESCRIPTION
Changes the behavior of the stats table to be live on updating data. More specifically, does not apply a 100ms delay and does not clear the table (to avoid flicker) when data is updated, though those still happen when the region is moved.

Also fixes the region tolerance code, to be a fraction of the region width instead of the absolute values. That would break badly when used with timestamps.

Architecturally, changes the cross-thread stats request from a queue to a shared variable guarded by a mutex.