### PR TITLE
Allow disabling stats calculation

### DIFF
--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -247,9 +247,9 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         self._plots.set_thickness(value)
         self._table.set_thickness(value)
 
-    def _on_disable_stats(self) -> None:
+    def _on_disable_stats(self, checked: bool) -> None:
         assert isinstance(self._table, StatsSignalsTable)
-        self._table.disable_stats(self._disable_stats_action.isChecked())
+        self._table.disable_stats(checked)
 
     def _make_controls(self) -> QWidget:
         button_load = QToolButton()
@@ -511,7 +511,8 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         data = self._data
         self._set_data({})  # blank the data while updates happen, for performance
         self._load_model(model)
-        self._disable_stats_action.setChecked(self._table._stats_calculation_disabled)
+        assert isinstance(self._table, StatsSignalsTable)
+        self._disable_stats_action.setChecked(self._table.stats_disabled())
 
         # force-update data items and data
         data_items = [(name, int_color(i), data_type) for i, (name, data_type) in enumerate(self._data_items.items())]

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -511,6 +511,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         data = self._data
         self._set_data({})  # blank the data while updates happen, for performance
         self._load_model(model)
+        self._disable_stats_action.setChecked(self._table._stats_calculation_disabled)
 
         # force-update data items and data
         data_items = [(name, int_color(i), data_type) for i, (name, data_type) in enumerate(self._data_items.items())]

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -247,6 +247,10 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         self._plots.set_thickness(value)
         self._table.set_thickness(value)
 
+    def _on_disable_stats(self) -> None:
+        assert isinstance(self._table, StatsSignalsTable)
+        self._table.disable_stats(self._disable_stats_action.isChecked())
+
     def _make_controls(self) -> QWidget:
         button_load = QToolButton()
         button_load.setText("Load CSV")
@@ -295,6 +299,10 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         line_width_action = QAction("Set Line Width", button_menu)
         line_width_action.triggered.connect(self._on_line_width_action)
         button_menu.addAction(line_width_action)
+        self._disable_stats_action = QAction("Disable Stats", button_menu)
+        self._disable_stats_action.setCheckable(True)
+        self._disable_stats_action.toggled.connect(self._on_disable_stats)
+        button_menu.addAction(self._disable_stats_action)
         animation_action = QAction("Create Animation", button_menu)
         animation_action.triggered.connect(partial(self._start_animation_ui_flow, ""))
         button_menu.addAction(animation_action)

--- a/pyqtgraph_scope_plots/stats_signals_table.py
+++ b/pyqtgraph_scope_plots/stats_signals_table.py
@@ -49,6 +49,8 @@ class StatsSignalsTable(HasRegionSignalsTable, HasSaveLoadDataConfig):
         COL_STAT_STDEV,
     ]
 
+    _MODEL_BASES = [StatsTableStateModel]
+
     _FULL_RANGE = (-float("inf"), float("inf"))
 
     class StatsCalculatorSignals(QObject):

--- a/tests/test_stats_table.py
+++ b/tests/test_stats_table.py
@@ -11,12 +11,14 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+from typing import cast
 
 import pytest
 from pytestqt.qtbot import QtBot
 
 
 from pyqtgraph_scope_plots import LinkedMultiPlotWidget, StatsSignalsTable
+from pyqtgraph_scope_plots.stats_signals_table import StatsTableStateModel
 from .common_testdata import DATA_ITEMS, DATA
 
 
@@ -102,4 +104,26 @@ def test_disable_enable(qtbot: QtBot, table: StatsSignalsTable) -> None:
             assert table.item(row, table.COL_STAT + col).text() == ""
 
     table.disable_stats(False)
+    qtbot.waitUntil(lambda: table.item(0, table.COL_STAT + table.COL_STAT_MIN).text() != "")
+
+
+def test_stats_table_save(qtbot: QtBot, table: StatsSignalsTable) -> None:
+    assert cast(StatsTableStateModel, table._dump_data_model([])).stats_disabled == False
+
+    table.disable_stats(True)
+    assert cast(StatsTableStateModel, table._dump_data_model([])).stats_disabled == True
+
+    table.disable_stats(False)
+    assert cast(StatsTableStateModel, table._dump_data_model([])).stats_disabled == False
+
+
+def test_stats_table_load(qtbot: QtBot, table: StatsSignalsTable) -> None:
+    model = cast(StatsTableStateModel, table._dump_data_model([]))
+
+    model.stats_disabled = True
+    table._load_model(model)
+    qtbot.waitUntil(lambda: table.item(0, table.COL_STAT + table.COL_STAT_MIN).text() == "")
+
+    model.stats_disabled = False
+    table._load_model(model)
     qtbot.waitUntil(lambda: table.item(0, table.COL_STAT + table.COL_STAT_MIN).text() != "")

--- a/tests/test_stats_table.py
+++ b/tests/test_stats_table.py
@@ -90,3 +90,16 @@ def test_region_empty(qtbot: QtBot, table: StatsSignalsTable) -> None:
     assert table.item(2, table.COL_STAT + table.COL_STAT_AVG).text() == ""
     assert table.item(2, table.COL_STAT + table.COL_STAT_RMS).text() == ""
     assert table.item(2, table.COL_STAT + table.COL_STAT_STDEV).text() == ""
+
+
+def test_disable_enable(qtbot: QtBot, table: StatsSignalsTable) -> None:
+    qtbot.waitUntil(lambda: table.item(0, table.COL_STAT + table.COL_STAT_MIN).text() != "")
+
+    table.disable_stats(True)
+    qtbot.waitUntil(lambda: table.item(0, table.COL_STAT + table.COL_STAT_MIN).text() == "")
+    for row in [0, 1, 2]:
+        for col in table.STATS_COLS:
+            assert table.item(row, table.COL_STAT + col).text() == ""
+
+    table.disable_stats(False)
+    qtbot.waitUntil(lambda: table.item(0, table.COL_STAT + table.COL_STAT_MIN).text() != "")


### PR DESCRIPTION
Add an API to the stats calculator table to disable calculation and plumb this through to the CSV viewer. This can reduce latency when capturing long data sets.