### PR TITLE
Add live filter mixin on signals table

### DIFF
--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -23,6 +23,7 @@ from .time_axis import TimeAxisItem
 from .multi_plot_widget import MultiPlotWidget, LinkedMultiPlotWidget, DroppableMultiPlotWidget
 from .signals_table import SignalsTable, DeleteableSignalsTable, DraggableSignalsTable
 from .search_signals_table import SearchSignalsTable
+from .filter_signals_table import FilterSignalsTable
 from .stats_signals_table import StatsSignalsTable
 from .color_signals_table import ColorPickerPlotWidget, ColorPickerSignalsTable
 from .timeshift_signals_table import TimeshiftPlotWidget, TimeshiftSignalsTable
@@ -63,6 +64,7 @@ __all__ = [
     "DeleteableSignalsTable",
     "DraggableSignalsTable",
     "SearchSignalsTable",
+    "FilterSignalsTable",
     "StatsSignalsTable",
     "ColorPickerPlotWidget",
     "ColorPickerSignalsTable",

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -47,7 +47,7 @@ from ..color_signals_table import ColorPickerSignalsTable, ColorPickerPlotWidget
 from ..multi_plot_widget import MultiPlotWidget
 from ..plots_table_widget import PlotsTableWidget
 from ..util import int_color, BaseTopModel, HasSaveLoadDataConfig
-from ..search_signals_table import SearchSignalsTable
+from ..filter_signals_table import FilterSignalsTable
 from ..stats_signals_table import StatsSignalsTable
 from ..time_axis import TimeAxisItem
 from ..timeshift_signals_table import TimeshiftSignalsTable, TimeshiftPlotWidget
@@ -148,7 +148,7 @@ class FullSignalsTable(
     ColorPickerSignalsTable,
     TimeshiftSignalsTable,
     TransformsSignalsTable,
-    SearchSignalsTable,
+    FilterSignalsTable,
     StatsSignalsTable,
     PlotsTableWidget.SignalsTable,
 ):

--- a/pyqtgraph_scope_plots/filter_signals_table.py
+++ b/pyqtgraph_scope_plots/filter_signals_table.py
@@ -59,6 +59,7 @@ class FilterOverlay(QWidget):
 
     def _on_close(self) -> None:
         self.close()
+        self._table.setFocus()  # revert focus to parent
 
     def closeEvent(self, event: QCloseEvent) -> None:
         self._table._apply_filter("")  # clear filters on close

--- a/pyqtgraph_scope_plots/filter_signals_table.py
+++ b/pyqtgraph_scope_plots/filter_signals_table.py
@@ -35,9 +35,9 @@ class FilterOverlay(QWidget):
 
         self._close_action = QAction("Close", self)
         self._close_action.setShortcut(Qt.Key.Key_Escape)
-        self._close_action.setShortcutContext(Qt.ShortcutContext.WidgetShortcut)  # require widget focus to fire
+        self._close_action.setShortcutContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
         self._close_action.triggered.connect(self._on_close)
-        self._filter_input.addAction(self._close_action)
+        self.addAction(self._close_action)
 
         self._results = QLabel("")
         self._results.setMinimumWidth(0)

--- a/pyqtgraph_scope_plots/filter_signals_table.py
+++ b/pyqtgraph_scope_plots/filter_signals_table.py
@@ -69,13 +69,11 @@ class FilterOverlay(QWidget):
 
         if not text:
             self._results.setText("")
-            self.adjustSize()
         elif count == 0:  # no results
             self._results.setText(f"no matches")
-            self.adjustSize()
         else:
             self._results.setText(f"{count} matches")
-            self.adjustSize()
+        self.adjustSize()
 
 
 class FilterSignalsTable(ContextMenuSignalsTable):

--- a/pyqtgraph_scope_plots/filter_signals_table.py
+++ b/pyqtgraph_scope_plots/filter_signals_table.py
@@ -54,8 +54,6 @@ class FilterOverlay(QWidget):
         self._filter_input.setText("")
         self._results.setText("")
         self.show()
-        self.raise_()
-        self.activateWindow()
         self.setFocus()
 
     def focusInEvent(self, event: QFocusEvent, /) -> None:

--- a/pyqtgraph_scope_plots/filter_signals_table.py
+++ b/pyqtgraph_scope_plots/filter_signals_table.py
@@ -16,8 +16,8 @@ from functools import partial
 from typing import Any
 
 from PySide6.QtCore import QKeyCombination, QPoint
-from PySide6.QtGui import QAction, Qt, QFocusEvent, QCloseEvent
-from PySide6.QtWidgets import QWidget, QLineEdit, QHBoxLayout, QPushButton, QLabel, QMenu
+from PySide6.QtGui import QAction, Qt, QFocusEvent, QCloseEvent, QColor
+from PySide6.QtWidgets import QWidget, QLineEdit, QHBoxLayout, QPushButton, QLabel, QMenu, QGraphicsDropShadowEffect
 
 from .signals_table import ContextMenuSignalsTable
 
@@ -26,7 +26,7 @@ class FilterOverlay(QWidget):
     def __init__(self, table: "FilterSignalsTable"):
         super().__init__(table)
         self._table = table
-        self.setWindowFlags(Qt.WindowType.Tool | Qt.WindowType.FramelessWindowHint)
+        self.setAutoFillBackground(True)
 
         self._filter_input = QLineEdit(self)
         self._filter_input.setMinimumWidth(200)
@@ -34,10 +34,6 @@ class FilterOverlay(QWidget):
         self._filter_input.setPlaceholderText("filter")
         self._filter_input.textEdited.connect(partial(self._on_filter, 0))
         self._filter_input.returnPressed.connect(partial(self._on_filter, 1))  # same as next
-
-        self._close_button = QPushButton("×")
-        self._close_button.setMaximumWidth(20)
-        self._close_button.clicked.connect(self._on_close)
 
         self._close_action = QAction("Close", self)
         self._close_action.setShortcut(Qt.Key.Key_Escape)
@@ -50,7 +46,6 @@ class FilterOverlay(QWidget):
 
         layout = QHBoxLayout(self)
         layout.addWidget(self._filter_input)
-        layout.addWidget(self._close_button)
         layout.addWidget(self._results)
         layout.setContentsMargins(0, 0, 0, 0)
 
@@ -59,6 +54,7 @@ class FilterOverlay(QWidget):
         self._filter_input.setText("")
         self._results.setText("")
         self.show()
+        self.raise_()
         self.activateWindow()
         self.setFocus()
 
@@ -105,7 +101,7 @@ class FilterSignalsTable(ContextMenuSignalsTable):
         menu.addAction(self._filter_action)
 
     def _on_filter(self) -> FilterOverlay:
-        self._filter_overlay.move(self.mapToGlobal(QPoint(0, 0)))
+        self._filter_overlay.move(QPoint(0, 0))
         self._filter_overlay.start()
         return self._filter_overlay
 

--- a/pyqtgraph_scope_plots/filter_signals_table.py
+++ b/pyqtgraph_scope_plots/filter_signals_table.py
@@ -1,0 +1,118 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import math
+from functools import partial
+from typing import Any, List
+
+from PySide6.QtCore import QKeyCombination, QPoint
+from PySide6.QtGui import QAction, Qt, QFocusEvent
+from PySide6.QtWidgets import QWidget, QLineEdit, QHBoxLayout, QPushButton, QLabel, QTableWidgetItem, QMenu
+
+from .signals_table import ContextMenuSignalsTable, SignalsTable
+
+
+class FilterOverlay(QWidget):
+    def __init__(self, table: "FilterSignalsTable"):
+        super().__init__(table)
+        self._table = table
+        self.setWindowFlags(Qt.WindowType.Popup)
+
+        self._filter_input = QLineEdit(self)
+        self._filter_input.setMinimumWidth(200)
+        self._filter_input.setMaximumWidth(200)
+        self._filter_input.setPlaceholderText("filter")
+        self._filter_input.textEdited.connect(partial(self._on_filter, 0))
+        self._filter_input.returnPressed.connect(partial(self._on_filter, 1))  # same as next
+
+        self._results = QLabel("")
+        self._results.setMinimumWidth(0)
+
+        layout = QHBoxLayout(self)
+        layout.addWidget(self._filter_input)
+        layout.addWidget(self._results)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+    def start(self) -> None:
+        """Re-initialize the filter overlay, eg when it is re-opened"""
+        self._filter_input.setText("")
+        self._results.setText("")
+
+    def focusInEvent(self, event: QFocusEvent, /) -> None:
+        self._filter_input.setFocus()
+
+    def _on_filter(self) -> None:
+        text = self._filter_input.text()
+        count = self._table._apply_filter(text)
+
+        if not text:
+            self._results.setText("")
+            self.adjustSize()
+            return
+
+        if count == 0:  # no results
+            self._results.setText(f"no matches")
+            self.adjustSize()
+            return  # specifically don't alter the user's selection
+        else:
+            self._results.setText(f"{count} matches")
+            self.adjustSize()
+
+
+class FilterSignalsTable(ContextMenuSignalsTable):
+    """Mixin into SignalsTable that adds filtering capability for signals via Ctrl+F."""
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._filter_action = QAction("Filter", self)
+        self._filter_action.setShortcut(QKeyCombination(Qt.KeyboardModifier.ControlModifier, Qt.Key.Key_F))
+        self._filter_action.setShortcutContext(Qt.ShortcutContext.WidgetShortcut)  # require widget focus to fire
+        self._filter_action.triggered.connect(self._on_filter)
+        self.addAction(self._filter_action)
+
+        self._filter_overlay = FilterOverlay(self)
+        self._filter_overlay.hide()
+
+    def _populate_context_menu(self, menu: QMenu) -> None:
+        super()._populate_context_menu(menu)
+        menu.addAction(self._filter_action)
+
+    def _on_filter(self) -> FilterOverlay:
+        self._filter_overlay.move(self.mapToGlobal(QPoint(0, 0)))
+        self._filter_overlay.start()
+        self._filter_overlay.show()
+        self._filter_overlay.setFocus()
+        return self._filter_overlay
+
+    def _apply_filter(self, text: str) -> int:
+        """Applies a filter on the rows, returning the number of matching rows. Use empty-string to clear filters."""
+
+        # start scanning results at the last of the user's selection
+        selected_rows = [item.row() for item in self._table.selectedItems()]
+        if selected_rows:
+            start_row = max(selected_rows)
+        else:
+            start_row = 0
+
+        match_items: List[QTableWidgetItem] = []
+        row_range = list(range(0, self._table.rowCount()))
+        row_range = row_range[start_row:] + row_range[:start_row]
+        for row in row_range:
+            item = self._table.item(row, self._table.COL_NAME)
+            if item and text in item.text().lower():
+                match_items.append(item)
+
+    def _update(self) -> None:
+        super()._update()
+        self._filter_overlay.hide()  # clear the filter on an update, which regenerates the table

--- a/pyqtgraph_scope_plots/filter_signals_table.py
+++ b/pyqtgraph_scope_plots/filter_signals_table.py
@@ -12,12 +12,11 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from functools import partial
 from typing import Any
 
 from PySide6.QtCore import QKeyCombination, QPoint
-from PySide6.QtGui import QAction, Qt, QFocusEvent, QCloseEvent, QColor
-from PySide6.QtWidgets import QWidget, QLineEdit, QHBoxLayout, QPushButton, QLabel, QMenu, QGraphicsDropShadowEffect
+from PySide6.QtGui import QAction, Qt, QFocusEvent, QCloseEvent
+from PySide6.QtWidgets import QWidget, QLineEdit, QHBoxLayout, QLabel, QMenu
 
 from .signals_table import ContextMenuSignalsTable
 
@@ -32,8 +31,7 @@ class FilterOverlay(QWidget):
         self._filter_input.setMinimumWidth(200)
         self._filter_input.setMaximumWidth(200)
         self._filter_input.setPlaceholderText("filter")
-        self._filter_input.textEdited.connect(partial(self._on_filter, 0))
-        self._filter_input.returnPressed.connect(partial(self._on_filter, 1))  # same as next
+        self._filter_input.textEdited.connect(self._on_filter)
 
         self._close_action = QAction("Close", self)
         self._close_action.setShortcut(Qt.Key.Key_Escape)
@@ -65,8 +63,7 @@ class FilterOverlay(QWidget):
     def closeEvent(self, event: QCloseEvent) -> None:
         self._table._apply_filter("")  # clear filters on close
 
-    def _on_filter(self, *args: Any) -> None:
-        text = self._filter_input.text()
+    def _on_filter(self, text: str) -> None:
         count = self._table._apply_filter(text)
 
         if not text:

--- a/pyqtgraph_scope_plots/signals_table.py
+++ b/pyqtgraph_scope_plots/signals_table.py
@@ -57,7 +57,6 @@ class SignalsTable(MixinColsTable):
 
         self._data_items: Dict[str, QColor] = {}
 
-        self._update()
         self._plots.sigDataItemsUpdated.connect(self._update)
 
     def _update(self) -> None:

--- a/tests/test_droppable_plot.py
+++ b/tests/test_droppable_plot.py
@@ -38,6 +38,7 @@ def plots(qtbot: QtBot) -> DroppableMultiPlotWidget:
 
 def test_plot_merge(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None:
     table = SignalsTable(plots)
+    table._update()
 
     qtbot.waitUntil(lambda: plots.count() == 3)  # wait for plots to be ready
 

--- a/tests/test_table_filter.py
+++ b/tests/test_table_filter.py
@@ -1,0 +1,82 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import pytest
+from PySide6.QtGui import QColor
+from pytestqt.qtbot import QtBot
+
+from pyqtgraph_scope_plots import MultiPlotWidget, FilterSignalsTable
+
+
+@pytest.fixture()
+def filter_table(qtbot: QtBot) -> FilterSignalsTable:
+    """Creates a signals plot with multiple data items"""
+    plots = MultiPlotWidget()
+    table = FilterSignalsTable(plots)
+    plots.show_data_items(
+        [
+            ("aaa", QColor("yellow"), MultiPlotWidget.PlotType.DEFAULT),
+            ("abC", QColor("orange"), MultiPlotWidget.PlotType.DEFAULT),
+            ("abd", QColor("blue"), MultiPlotWidget.PlotType.DEFAULT),
+        ]
+    )
+    qtbot.addWidget(table)
+    table.show()
+    qtbot.waitExposed(table)
+    return table
+
+
+def test_filter_empty(qtbot: QtBot, filter_table: FilterSignalsTable) -> None:
+    filter_tool = filter_table._on_filter()
+    assert filter_tool.isVisible()
+
+
+def test_filter_nomatch(qtbot: QtBot, filter_table: FilterSignalsTable) -> None:
+    filter_tool = filter_table._on_filter()
+    filter_tool._filter_input.setText("ducks")
+    filter_tool._filter_input.textEdited.emit("ducks")
+    qtbot.waitUntil(lambda: filter_tool._results.text().lower() == "no matches")
+    assert filter_table.isRowHidden(0)
+    assert filter_table.isRowHidden(1)
+    assert filter_table.isRowHidden(2)
+
+
+def test_filter_single(qtbot: QtBot, filter_table: FilterSignalsTable) -> None:
+    filter = filter_table._on_filter()
+    filter._filter_input.setText("aaa")
+    filter._filter_input.textEdited.emit("aaa")
+    qtbot.waitUntil(lambda: filter._results.text().lower() == "1 matches")
+    assert not filter_table.isRowHidden(0)
+    assert filter_table.isRowHidden(1)
+    assert filter_table.isRowHidden(2)
+
+
+def test_filter_case_insensitive(qtbot: QtBot, filter_table: FilterSignalsTable) -> None:
+    filter_tool = filter_table._on_filter()
+    filter_tool._filter_input.setText("ABc")
+    filter_tool._filter_input.textEdited.emit("ABc")
+    qtbot.waitUntil(lambda: filter_tool._results.text().lower() == "1 matches")
+    assert filter_table.isRowHidden(0)
+    assert not filter_table.isRowHidden(1)
+    assert filter_table.isRowHidden(2)
+
+
+def test_filter_multiple(qtbot: QtBot, filter_table: FilterSignalsTable) -> None:
+    filter_tool = filter_table._on_filter()
+    filter_tool._filter_input.setText("b")
+    filter_tool._filter_input.textEdited.emit("b")
+    qtbot.waitUntil(lambda: filter_tool._results.text().lower() == "2 matches")
+    assert filter_table.isRowHidden(0)
+    assert not filter_table.isRowHidden(1)
+    assert not filter_table.isRowHidden(2)

--- a/tests/test_timeshift.py
+++ b/tests/test_timeshift.py
@@ -35,6 +35,7 @@ def timeshifts_plots(qtbot: QtBot) -> TimeshiftPlotWidget:
 
 def test_timeshift(qtbot: QtBot, timeshifts_plots: TimeshiftPlotWidget) -> None:
     timeshifts_table = TimeshiftSignalsTable(timeshifts_plots)
+    timeshifts_table._update()
     # test empty
     qtbot.waitUntil(lambda: timeshifts_plots._apply_timeshift("0", DATA).tolist() == [0.0, 0.1, 1.0, 2.0])
     timeshifts_plots.set_timeshift(["0"], 1)
@@ -50,6 +51,7 @@ def test_timeshift(qtbot: QtBot, timeshifts_plots: TimeshiftPlotWidget) -> None:
 
 def test_timeshift_table(qtbot: QtBot, timeshifts_plots: TimeshiftPlotWidget) -> None:
     timeshifts_table = TimeshiftSignalsTable(timeshifts_plots)
+    timeshifts_table._update()
     timeshifts_table.item(0, timeshifts_table.COL_TIMESHIFT).setText("1")
     timeshifts_table.cellChanged.emit(0, timeshifts_table.COL_TIMESHIFT)
     qtbot.waitUntil(lambda: timeshifts_plots._apply_timeshift("0", DATA).tolist() == [1.0, 1.1, 2.0, 3.0])

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -15,10 +15,10 @@
 from typing import cast
 
 import pytest
-from PySide6.QtGui import QColor, Qt
+from PySide6.QtGui import Qt
 from pytestqt.qtbot import QtBot
 
-from pyqtgraph_scope_plots import MultiPlotWidget, VisibilityPlotWidget, VisibilityToggleSignalsTable
+from pyqtgraph_scope_plots import VisibilityPlotWidget, VisibilityToggleSignalsTable
 from pyqtgraph_scope_plots.visibility_toggle_table import VisibilityDataStateModel
 from .common_testdata import DATA_ITEMS, DATA
 
@@ -63,6 +63,7 @@ def test_visibility(qtbot: QtBot, visibility_plots: VisibilityPlotWidget) -> Non
 
 def test_visibility_table(qtbot: QtBot, visibility_plots: VisibilityPlotWidget) -> None:
     visibility_table = VisibilityToggleSignalsTable(visibility_plots)
+    visibility_table._update()
     visibility_table.item(1, visibility_table.COL_VISIBILITY).setCheckState(Qt.CheckState.Unchecked)
     qtbot.waitUntil(lambda: not visibility_plots._data_curves["1"][0].isVisible())
     assert visibility_plots._data_curves["0"][0].isVisible()  # check unchanged


### PR DESCRIPTION
As an alternative to the search mixin, add a filter mixin that has the same textbox popup but live filters the rows shown on the table. On new data items defined, the filter mixin clears. Changes the CSV viewer to use this by default.

The filter uses new matching logic that finds all substrings (separated by whitespace in the filter box) in table text, even if noncontiguous.

Also changes table behavior to no longer _update() in __init__(), since in practice it does nothing (no data is defined, unless the table was late-constructed which typically only happens in tests) and it calls _update() before subclass __init__() have finished.