### PR TITLE
Recents menu

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,7 +25,8 @@ jobs:
         python-version: "3.10"
     - name: Install dependencies
       run: |
-        sudo apt-get install -y libgl1 libegl1 libxkbcommon-x11-0 libdbus-1-3
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends -y libgl1 libegl1 libxkbcommon-x11-0 libdbus-1-3
         pip install -e .[dev]
         pip freeze  # dump debug info on packages
     - name: Check Black style

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -267,6 +267,20 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         button_load.setArrowType(Qt.ArrowType.DownArrow)
         button_load.setMenu(menu_load)
 
+        button_load_config = QToolButton()
+        button_load_config.setText("Load Config")
+        button_load_config.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        button_load_config.setSizePolicy(QtWidgets.QSizePolicy.Policy.Preferred, QtWidgets.QSizePolicy.Policy.Fixed)
+        button_load_config.clicked.connect(self._on_load_config)
+
+        self._menu_config = QMenu(self)
+        self._save_config_action = QAction("Save Config", self._menu_config)
+        self._save_config_action.triggered.connect(self._on_save_config)
+        button_load_config.setPopupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
+        button_load_config.setArrowType(Qt.ArrowType.DownArrow)
+        button_load_config.setMenu(self._menu_config)
+        self._menu_config.aboutToShow.connect(self._populate_config_menu())
+
         button_refresh = QToolButton()
         button_refresh.setText("Refresh CSV")
         button_refresh.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
@@ -308,20 +322,20 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         button_menu.addAction(animation_action)
         button_visuals.setMenu(button_menu)
 
-        save_config_action = QAction("Save Config", button_menu)
-        save_config_action.triggered.connect(self._on_save_config)
-        button_menu.addAction(save_config_action)
-        load_config_action = QAction("Load Config", button_menu)
-        load_config_action.triggered.connect(self._on_load_config)
-        button_menu.addAction(load_config_action)
-
         layout = QVBoxLayout()
         layout.addWidget(button_load)
+        layout.addWidget(button_load_config)
         layout.addWidget(button_refresh)
         layout.addWidget(button_visuals)
         widget = QWidget()
         widget.setLayout(layout)
         return widget
+
+    def _populate_config_menu(self) -> None:
+        self._menu_config.clear()
+        self._menu_config.addAction(self._save_config_action)
+
+        # TODO IMPLEMENT RECENTS
 
     def _on_load_csv(self) -> None:
         csv_filenames, _ = QFileDialog.getOpenFileNames(None, "Select CSV Files", filter="CSV files (*.csv)")

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -355,7 +355,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
     def _load_recents(self) -> CsvLoaderRecents:
         recents_val = cast(str, self._config().value(self._RECENTS_CONFIG_KEY, ""))
         try:
-            return CsvLoaderRecents.validate(CsvLoaderRecents(**yaml.load(recents_val, Loader=TupleSafeLoader)))
+            return CsvLoaderRecents.model_validate(CsvLoaderRecents(**yaml.load(recents_val, Loader=TupleSafeLoader)))
         except Exception as e:
             return CsvLoaderRecents()
 
@@ -541,8 +541,6 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         model = self._do_save_config(filename)
         with open(filename, "w") as f:
             f.write(yaml.dump(model.model_dump(), sort_keys=False))
-        self._loaded_config_abspath = os.path.abspath(filename)
-        self._append_recent()
 
     def _do_save_config(self, filename: str) -> CsvLoaderStateModel:
         model = self._dump_data_model(self._plots._data_items.keys())
@@ -569,6 +567,9 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
                 ]
             else:  # save as abspath, would need .. access to get CSVs
                 model.csv_files = [os.path.abspath(csv_filename) for csv_filename in self._csv_data_items.keys()]
+
+        self._loaded_config_abspath = os.path.abspath(filename)
+        self._append_recent()
 
         return model
 

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -413,6 +413,10 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         if self._loaded_config_abspath in recents.recents:
             recents.recents.remove(self._loaded_config_abspath)
         recents.recents.insert(0, self._loaded_config_abspath)
+        excess_recents = len(recents.recents) + len(recents.hotkeys) - self._RECENTS_MAX
+        if excess_recents > 0:
+            recents.recents = recents.recents[:-excess_recents]
+
         self._config().setValue(self._RECENTS_CONFIG_KEY, yaml.dump(recents.model_dump(), sort_keys=False))
 
     def _on_load_csv(self) -> None:

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -391,7 +391,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         assert self._loaded_config_abspath
         recents = self._load_recents()
 
-        hotkey, ok = QInputDialog.getInt(self, "Set Hotkey (0-9)", "", value=0, minValue=0, maxValue=9)
+        hotkey, ok = QInputDialog.getInt(self, "Set Hotkey Slot", "", value=0, minValue=0, maxValue=9)
         if not ok:
             return
 

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -23,7 +23,7 @@ from pytestqt.qtbot import QtBot
 from pyqtgraph_scope_plots.multi_plot_widget import MultiPlotStateModel, PlotWidgetModel
 from pyqtgraph_scope_plots import MultiPlotWidget, PlotsTableWidget
 from .common_testdata import DATA_ITEMS, DATA
-from .test_util import assert_cast
+from .util import assert_cast
 
 
 @pytest.fixture()

--- a/tests/test_csv_viewer.py
+++ b/tests/test_csv_viewer.py
@@ -19,7 +19,8 @@ from unittest import mock
 import pytest
 from pytestqt.qtbot import QtBot
 
-from pyqtgraph_scope_plots.csv.csv_plots import CsvLoaderPlotsTableWidget
+from pyqtgraph_scope_plots.csv.csv_plots import CsvLoaderPlotsTableWidget, CsvLoaderRecents
+from tests.util import MockQSettings
 
 
 @pytest.fixture()
@@ -75,6 +76,7 @@ def test_watch_stability(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
         qtbot.waitUntil(lambda: mock_load_csv.called)  # check the load happens
 
 
+@mock.patch.object(CsvLoaderPlotsTableWidget, "_config", lambda *args: MockQSettings())
 def test_save_model_csvs(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
     # test empty save
     model = plot._do_save_config(os.path.join(os.path.dirname(__file__), "config.yml"))
@@ -93,6 +95,7 @@ def test_save_model_csvs(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
     ]
 
 
+@mock.patch.object(CsvLoaderPlotsTableWidget, "_config", lambda *args: MockQSettings())
 def test_load_model_csvs_relpath(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
     model = plot._do_save_config("/config.yml")
 
@@ -114,3 +117,16 @@ def test_load_model_csvs_relpath(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) 
         mock_load_csv.assert_called_with(
             [os.path.join(os.path.dirname(__file__), "data", "test_csv_viewer_data.csv")], update=False
         )
+
+
+def test_recents_save(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
+    settings = MockQSettings()
+    with mock.patch.object(CsvLoaderPlotsTableWidget, "_config", lambda *args: settings):
+        assert plot._load_recents() == CsvLoaderRecents()
+        plot._do_save_config("/config.yml")  # stores to recents
+        assert plot._load_recents().recents == [os.path.abspath("/config.yml")]
+
+
+@mock.patch.object(CsvLoaderPlotsTableWidget, "_config", lambda *args: MockQSettings())
+def test_recents_load(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
+    pass

--- a/tests/test_csv_viewer.py
+++ b/tests/test_csv_viewer.py
@@ -124,19 +124,19 @@ def test_load_model_csvs_relpath(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) 
 def test_recents_save(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
     settings = MockQSettings()
     with mock.patch.object(CsvLoaderPlotsTableWidget, "_config", lambda *args: settings):
-        assert plot._load_recents() == CsvLoaderRecents()
+        assert plot._get_recents() == CsvLoaderRecents()
         model = plot._do_save_config("/config.yml")  # stores to recents
-        assert plot._load_recents().recents == [os.path.abspath("/config.yml")]
+        assert plot._get_recents().recents == [os.path.abspath("/config.yml")]
 
         plot._do_load_config(os.path.join(os.path.dirname(__file__), "test.yml"), model)
-        assert plot._load_recents().recents == [
+        assert plot._get_recents().recents == [
             os.path.abspath(os.path.join(os.path.dirname(__file__), "test.yml")),
             os.path.abspath("/config.yml"),
         ]
 
         # check reordering latest-first + dedup
         plot._do_load_config("/config.yml", model)
-        assert plot._load_recents().recents == [
+        assert plot._get_recents().recents == [
             os.path.abspath("/config.yml"),
             os.path.abspath(os.path.join(os.path.dirname(__file__), "test.yml")),
         ]
@@ -144,33 +144,33 @@ def test_recents_save(qtbot: QtBot, plot: CsvLoaderPlotsTableWidget) -> None:
         # check pruning
         for i in range(10):
             plot._do_load_config(f"/extra{i}.yml", model)
-        assert len(plot._load_recents().recents) == 9
+        assert len(plot._get_recents().recents) == 9
 
         # check hotkeys
         with mock.patch.object(QInputDialog, "getInt", lambda *args, **kwargs: (8, True)):
             plot._on_set_hotkey()
-        assert plot._load_recents().hotkeys[8] == os.path.abspath(f"/extra9.yml")
-        assert len(plot._load_recents().recents) == 8
-        assert os.path.abspath(f"/extra9.yml") not in plot._load_recents().recents
-        assert os.path.abspath(f"/extra8.yml") in plot._load_recents().recents
+        assert plot._get_recents().hotkeys[8] == os.path.abspath(f"/extra9.yml")
+        assert len(plot._get_recents().recents) == 8
+        assert os.path.abspath(f"/extra9.yml") not in plot._get_recents().recents
+        assert os.path.abspath(f"/extra8.yml") in plot._get_recents().recents
 
         # check most recent pruned
         plot._do_load_config(f"/extra11.yml", model)
-        assert plot._load_recents().hotkeys[8] == os.path.abspath(f"/extra9.yml")
-        assert len(plot._load_recents().recents) == 8
-        assert os.path.abspath(f"/extra0.yml") not in plot._load_recents().recents
-        assert os.path.abspath(f"/extra11.yml") in plot._load_recents().recents
+        assert plot._get_recents().hotkeys[8] == os.path.abspath(f"/extra9.yml")
+        assert len(plot._get_recents().recents) == 8
+        assert os.path.abspath(f"/extra0.yml") not in plot._get_recents().recents
+        assert os.path.abspath(f"/extra11.yml") in plot._get_recents().recents
 
         # check that it is possible to max out the hotkey range
         for i in range(10):
             plot._do_load_config(f"/extra{i}.yml", model)
             with mock.patch.object(QInputDialog, "getInt", lambda *args, **kwargs: (i, True)):
                 plot._on_set_hotkey()
-        assert len(plot._load_recents().recents) == 0
+        assert len(plot._get_recents().recents) == 0
 
         # recents no longer saves, hotkeys take priority
         plot._do_load_config(f"/extra11.yml", model)
-        assert len(plot._load_recents().recents) == 0
+        assert len(plot._get_recents().recents) == 0
 
 
 @mock.patch.object(CsvLoaderPlotsTableWidget, "load_config_file")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -25,7 +25,7 @@ from pyqtgraph_scope_plots.code_input_dialog import CodeInputDialog
 from pyqtgraph_scope_plots.transforms_signal_table import TransformsDataStateModel
 from pyqtgraph_scope_plots.util.util import not_none
 from .common_testdata import DATA
-from .test_util import context_menu, menu_action_by_name
+from .util import context_menu, menu_action_by_name
 
 
 @pytest.fixture()

--- a/tests/util.py
+++ b/tests/util.py
@@ -12,7 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from typing import TypeVar, Type, Any
+from typing import TypeVar, Type, Any, Optional, Dict
+from unittest import mock
 
 from PySide6.QtCore import Qt, QPoint
 from PySide6.QtGui import QAction
@@ -55,3 +56,17 @@ def menu_action_by_name(menu: QMenu, *text: str) -> QAction:
         if not item_found:
             raise ValueError(f"No menu item with {current_text} in {[action.text() for action in menu.actions()]}")
     raise ValueError()  # shouldn't happen, here to satisfy the type checker
+
+
+class MockQSettings(mock.MagicMock):
+    def __init__(self, *args: Any, settings_values: Optional[Dict[str, Any]] = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._values: Dict[str, Any] = {}
+        if settings_values:
+            self._values.update(settings_values)
+
+    def value(self, key: str, default: Any = None) -> Optional[Any]:
+        return self._values.get(key, default)
+
+    def setValue(self, key: str, value: Any) -> None:
+        self._values[key] = value

--- a/tests/util.py
+++ b/tests/util.py
@@ -42,7 +42,7 @@ def context_menu(qtbot: QtBot, container: QWidget, target: QPoint = QPoint(0, 0)
     return assert_cast(QMenu, container.findChild(QMenu))
 
 
-def menu_action_by_name(menu: QMenu, *text: str) -> QAction:
+def menu_action_by_name(menu: QMenu, *text: str) -> Optional[QAction]:
     """Given a menu, returns the first action that contains the specified text, case-insensitive"""
     for i, current_text in enumerate(text):
         item_found = False
@@ -54,8 +54,8 @@ def menu_action_by_name(menu: QMenu, *text: str) -> QAction:
                 else:  # final step, return the action
                     return action
         if not item_found:
-            raise ValueError(f"No menu item with {current_text} in {[action.text() for action in menu.actions()]}")
-    raise ValueError()  # shouldn't happen, here to satisfy the type checker
+            return None
+    return None  # shouldn't happen, here to satisfy the type checker
 
 
 class MockQSettings(mock.MagicMock):


### PR DESCRIPTION
Moves load config to its own top-level button, and add a dropdown to it that keeps recent items. Recent items are saved to a machine-wide config (via QSettings) and can be pinned and assigned hotkeys for loading. Adds unit tests for saving and loading recents.

Other changes
- Add model validation when loading yamls
- Cleaning up of tests
