### PR TITLE
Separate out RecentsManager, add save/load to the base PlotsTableWidget

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pyqtgraph-scope-plots"
 description = "Scope like plot utilities for pyqtgraph"
 readme = "README.md"
-version = "1.5.1"
+version = "1.5.2"
 authors = [
     { name = "Richard Lin", email = "richardlin@enphaseenergy.com" }
 ]

--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -49,8 +49,8 @@ from .xy_plot_splitter import XyPlotSplitter
 from .xy_plot_table import XyTable
 from .xy_plot_legends import XyTableLegends
 
-# top-level mixins
-from .recents import BaseRecents
+# misc utils
+from .recents import RecentsManager
 
 
 __all__ = [
@@ -94,5 +94,5 @@ __all__ = [
     "XyPlotSplitter",
     "XyTable",
     "XyTableLegends",
-    "BaseRecents",
+    "RecentsManager",
 ]

--- a/pyqtgraph_scope_plots/__init__.py
+++ b/pyqtgraph_scope_plots/__init__.py
@@ -49,6 +49,9 @@ from .xy_plot_splitter import XyPlotSplitter
 from .xy_plot_table import XyTable
 from .xy_plot_legends import XyTableLegends
 
+# top-level mixins
+from .recents import BaseRecents
+
 
 __all__ = [
     "HasSaveLoadConfig",
@@ -91,4 +94,5 @@ __all__ = [
     "XyPlotSplitter",
     "XyTable",
     "XyTableLegends",
+    "BaseRecents",
 ]

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -209,32 +209,6 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         )
         self._recents.bind_hotkeys(self)
 
-    @classmethod
-    def _get_all_model_bases(cls) -> List[Type[BaseModel]]:
-        bases = super()._get_all_model_bases()
-        plot_bases = cls._PLOT_TYPE._get_all_model_bases()
-        table_bases = cls._TABLE_TYPE._get_all_model_bases()
-        return bases + plot_bases + table_bases
-
-    @classmethod
-    def _get_data_model_bases(cls) -> List[Type[BaseModel]]:
-        bases = super()._get_data_model_bases()
-        plot_bases = cls._PLOT_TYPE._get_data_model_bases()
-        table_bases = cls._TABLE_TYPE._get_data_model_bases()
-        return bases + plot_bases + table_bases
-
-    def _write_model(self, model: BaseModel) -> None:
-        super()._write_model(model)
-        assert isinstance(self._table, HasSaveLoadDataConfig)
-        self._table._write_model(model)
-        self._plots._write_model(model)
-
-    def _load_model(self, model: BaseModel) -> None:
-        super()._load_model(model)
-        assert isinstance(self._table, HasSaveLoadDataConfig)
-        self._table._load_model(model)
-        self._plots._load_model(model)
-
     def _on_legend_checked(self) -> None:
         assert isinstance(self._plots, FullPlots)
         assert isinstance(self._table, FullSignalsTable)

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -341,7 +341,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         self._menu_config.addAction(save_config_action)
 
         self._menu_config.addSeparator()
-        self._populate_recents_menu(self._menu_config)
+        self._recents.populate_recents_menu(self._menu_config)
 
     def _on_load_csv(self) -> None:
         csv_filenames, _ = QFileDialog.getOpenFileNames(None, "Select CSV Files", filter="CSV files (*.csv)")

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -36,7 +36,6 @@ from PySide6.QtWidgets import (
     QToolButton,
     QMessageBox,
 )
-from pydantic import BaseModel, ValidationError
 
 from ..legend_plot_widget import LegendPlotWidget
 from ..recents import RecentsManager

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -16,7 +16,7 @@ import itertools
 import os.path
 import time
 from functools import partial
-from typing import Dict, Tuple, Any, List, Optional, Callable, Sequence, cast, Set, Iterable, Type, Union, TextIO
+from typing import Dict, Tuple, Any, List, Optional, Callable, Sequence, cast, Set, Iterable, Type
 
 import numpy as np
 import numpy.typing as npt
@@ -204,7 +204,9 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         self._watch_timer.setInterval(self.WATCH_INTERVAL_MS)
         self._watch_timer.timeout.connect(self._check_watch)
 
-        self._recents = RecentsManager(QSettings("scope-plots", "csv"), "recents", self.load_config_file)
+        self._recents = RecentsManager(
+            QSettings("scope-plots", "csv"), "recents", lambda filename: self.load_config_file(filename)
+        )
         self._recents.bind_hotkeys(self)
 
     @classmethod

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -39,7 +39,7 @@ from PySide6.QtWidgets import (
 from pydantic import BaseModel, ValidationError
 
 from ..legend_plot_widget import LegendPlotWidget
-from ..recents import BaseRecents
+from ..recents import RecentsManager
 from ..xy_plot_legends import XyTableLegends
 from ..xy_plot_visibility import VisibilityXyPlotWidget, VisibilityXyPlotTable
 from ..visibility_toggle_table import VisibilityToggleSignalsTable, VisibilityPlotWidget
@@ -178,7 +178,7 @@ class FullSignalsTable(
             xy_plot.set_thickness(thickness)
 
 
-class CsvLoaderPlotsTableWidget(BaseRecents, AnimationPlotsTableWidget, PlotsTableWidget, HasSaveLoadDataConfig):
+class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, HasSaveLoadDataConfig):
     """Example app-level widget that loads CSV files into the plotter"""
 
     _MODEL_BASES = [CsvLoaderStateModel]
@@ -204,6 +204,9 @@ class CsvLoaderPlotsTableWidget(BaseRecents, AnimationPlotsTableWidget, PlotsTab
         self._watch_timer = QTimer()
         self._watch_timer.setInterval(self.WATCH_INTERVAL_MS)
         self._watch_timer.timeout.connect(self._check_watch)
+
+        self._recents = RecentsManager(QSettings("scope-plots", "csv"), "recents", self.load_config_file)
+        self._recents.bind_hotkeys(self)
 
     @classmethod
     def _get_all_model_bases(cls) -> List[Type[BaseModel]]:
@@ -498,7 +501,7 @@ class CsvLoaderPlotsTableWidget(BaseRecents, AnimationPlotsTableWidget, PlotsTab
                 model.csv_files = [os.path.abspath(csv_filename) for csv_filename in self._csv_data_items.keys()]
 
         self._loaded_config_abspath = os.path.abspath(filename)
-        self._append_recent(self._loaded_config_abspath)
+        self._recents.append_recent(self._loaded_config_abspath)
 
         return model
 
@@ -546,4 +549,4 @@ class CsvLoaderPlotsTableWidget(BaseRecents, AnimationPlotsTableWidget, PlotsTab
         self._set_data_items(data_items)
         self._set_data(data)  # bulk update everything for performance
         self._loaded_config_abspath = os.path.abspath(filename)
-        self._append_recent(self._loaded_config_abspath)
+        self._recents.append_recent(self._loaded_config_abspath)

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -190,7 +190,6 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
 
     def __init__(self, x_axis: Optional[Callable[[], pg.AxisItem]] = None) -> None:
         self._x_axis = x_axis
-        self._loaded_config_abspath = ""  # of last loaded config file, even if it has changed
 
         super().__init__()
 
@@ -500,8 +499,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
             else:  # save as abspath, would need .. access to get CSVs
                 model.csv_files = [os.path.abspath(csv_filename) for csv_filename in self._csv_data_items.keys()]
 
-        self._loaded_config_abspath = os.path.abspath(filename)
-        self._recents.append_recent(self._loaded_config_abspath)
+        self._recents.file_changed(filename)
 
         return model
 
@@ -548,5 +546,4 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         data_items = [(name, int_color(i), data_type) for i, (name, data_type) in enumerate(self._data_items.items())]
         self._set_data_items(data_items)
         self._set_data(data)  # bulk update everything for performance
-        self._loaded_config_abspath = os.path.abspath(filename)
-        self._recents.append_recent(self._loaded_config_abspath)
+        self._recents.file_changed(filename)

--- a/pyqtgraph_scope_plots/recents.py
+++ b/pyqtgraph_scope_plots/recents.py
@@ -1,0 +1,98 @@
+import os
+from functools import partial
+from typing import Any, Dict, List, cast
+
+import yaml
+from PySide6.QtCore import QSettings, QKeyCombination
+from PySide6.QtGui import QAction, Qt
+from PySide6.QtWidgets import QWidget, QInputDialog, QMenu
+from pydantic import BaseModel, ValidationError
+
+
+class RecentsModel(BaseModel):
+    """Data storage model for recents"""
+
+    hotkeys: Dict[int, str] = {}  # hotkey number -> file
+    recents: List[str] = []  # most recent first
+
+
+class BaseRecents(QWidget):
+    """Mixin to support recents on a top-level GUI"""
+
+    _RECENTS_MAX = 9  # hotkeys + recents is pruned to this count
+    _RECENTS_CONFIG_KEY = "recents"  # key for QSettings - REPLACE ME
+
+    _RECENTS_SETTINGS = QSettings("scope-plots", "csv")
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self._load_hotkey_actions = []
+        for i in range(10):
+            load_hotkey_action = QAction(f"", self)
+            load_hotkey_action.setShortcut(
+                QKeyCombination(Qt.KeyboardModifier.ControlModifier, Qt.Key(Qt.Key.Key_0 + i))
+            )
+            load_hotkey_action.setShortcutContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
+            load_hotkey_action.triggered.connect(partial(self._load_hotkey_slot, i))
+            self.addAction(load_hotkey_action)
+            self._load_hotkey_actions.append(load_hotkey_action)
+
+    def _get_recents(self) -> RecentsModel:
+        recents_val = cast(str, self._RECENTS_SETTINGS.value(self._RECENTS_CONFIG_KEY, ""))
+        try:
+            return RecentsModel.model_validate(RecentsModel(**yaml.load(recents_val, Loader=TupleSafeLoader)))
+        except (yaml.YAMLError, TypeError, ValidationError):
+            return RecentsModel()
+
+    def _populate_recents_menu(self, menu: QMenu) -> None:
+        recents = self._get_recents()
+        for hotkey, recent in sorted(recents.hotkeys.items(), key=lambda x: x[0]):
+            load_hotkey_action = self._load_hotkey_actions[hotkey]  # crash on invalid index
+            load_hotkey_action.setText(f"{os.path.split(recent)[1]}")
+            menu.addAction(load_hotkey_action)
+
+        for recent in recents.recents:
+            load_action = QAction(f"{os.path.split(recent)[1]}", menu)
+            load_action.triggered.connect(partial(self.load_config_file, recent))
+            menu.addAction(load_action)
+
+        menu.addSeparator()
+        set_hotkey_action = QAction("Set Hotkey", menu)
+        set_hotkey_action.triggered.connect(self._on_set_hotkey)
+        if self._loaded_config_abspath:
+            set_hotkey_action.setText(f"Set Hotkey for {os.path.split(self._loaded_config_abspath)[1]}")
+        else:
+            set_hotkey_action.setDisabled(True)
+        menu.addAction(set_hotkey_action)
+
+    def _on_set_hotkey(self) -> None:
+        assert self._loaded_config_abspath  # shouldn't be triggerable unless something loaded
+        recents = self._get_recents()
+
+        hotkey, ok = QInputDialog.getInt(self, "Set Hotkey Slot", "", value=0, minValue=0, maxValue=9)
+        if not ok:
+            return
+
+        if self._loaded_config_abspath in recents.recents:
+            recents.recents.remove(self._loaded_config_abspath)
+        recents.hotkeys[hotkey] = self._loaded_config_abspath
+        self._RECENTS_SETTINGS.setValue(self._RECENTS_CONFIG_KEY, yaml.dump(recents.model_dump(), sort_keys=False))
+
+    def _load_hotkey_slot(self, slot: int) -> None:
+        recents = self._get_recents()
+        target = recents.hotkeys.get(slot, None)
+        if target is not None:
+            self.load_config_file(target)
+
+    def _append_recent(self, filename: str) -> None:
+        recents = self._get_recents()
+        if self._loaded_config_abspath in recents.hotkeys.values():
+            return  # don't overwrite hotkeys
+        if self._loaded_config_abspath in recents.recents:
+            recents.recents.remove(self._loaded_config_abspath)
+        recents.recents.insert(0, self._loaded_config_abspath)
+        excess_recents = len(recents.recents) + len(recents.hotkeys) - self._RECENTS_MAX
+        if excess_recents > 0:
+            recents.recents = recents.recents[:-excess_recents]
+
+        self._RECENTS_SETTINGS.setValue(self._RECENTS_CONFIG_KEY, yaml.dump(recents.model_dump(), sort_keys=False))

--- a/pyqtgraph_scope_plots/recents.py
+++ b/pyqtgraph_scope_plots/recents.py
@@ -1,6 +1,6 @@
 import os
 from functools import partial
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, cast, Callable
 
 import yaml
 from PySide6.QtCore import QSettings, QKeyCombination
@@ -16,35 +16,38 @@ class RecentsModel(BaseModel):
     recents: List[str] = []  # most recent first
 
 
-class BaseRecents(QWidget):
-    """Mixin to support recents on a top-level GUI"""
+class RecentsManager:
+    """Class that manages recents, providing API hooks"""
 
     _RECENTS_MAX = 9  # hotkeys + recents is pruned to this count
-    _RECENTS_CONFIG_KEY = "recents"  # key for QSettings - REPLACE ME
 
-    _RECENTS_SETTINGS = QSettings("scope-plots", "csv")
-
-    def __init__(self, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
+    def __init__(self, settings: QSettings, config_key: str, load_fn: Callable[[str], None]) -> None:
         self._load_hotkey_actions = []
+        self._settings = settings
+        self._config_key = config_key
+        self._load_fn = load_fn
+
+    def bind_hotkeys(self, widget: QWidget) -> None:
+        """Binds recents-loading hotkeys to the specified widget."""
         for i in range(10):
-            load_hotkey_action = QAction(f"", self)
+            load_hotkey_action = QAction(f"", widget)
             load_hotkey_action.setShortcut(
                 QKeyCombination(Qt.KeyboardModifier.ControlModifier, Qt.Key(Qt.Key.Key_0 + i))
             )
             load_hotkey_action.setShortcutContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
             load_hotkey_action.triggered.connect(partial(self._load_hotkey_slot, i))
-            self.addAction(load_hotkey_action)
+            widget.addAction(load_hotkey_action)
             self._load_hotkey_actions.append(load_hotkey_action)
 
     def _get_recents(self) -> RecentsModel:
-        recents_val = cast(str, self._RECENTS_SETTINGS.value(self._RECENTS_CONFIG_KEY, ""))
+        recents_val = cast(str, self._settings.value(self._config_key, ""))
         try:
-            return RecentsModel.model_validate(RecentsModel(**yaml.load(recents_val, Loader=TupleSafeLoader)))
+            return RecentsModel.model_validate(RecentsModel(**yaml.safe_load(recents_val)))
         except (yaml.YAMLError, TypeError, ValidationError):
             return RecentsModel()
 
-    def _populate_recents_menu(self, menu: QMenu) -> None:
+    def populate_recents_menu(self, menu: QMenu) -> None:
+        """Add recents (including the item to bind a hotkey) to a menu."""
         recents = self._get_recents()
         for hotkey, recent in sorted(recents.hotkeys.items(), key=lambda x: x[0]):
             load_hotkey_action = self._load_hotkey_actions[hotkey]  # crash on invalid index
@@ -53,38 +56,38 @@ class BaseRecents(QWidget):
 
         for recent in recents.recents:
             load_action = QAction(f"{os.path.split(recent)[1]}", menu)
-            load_action.triggered.connect(partial(self.load_config_file, recent))
+            load_action.triggered.connect(partial(self._load_fn, recent))
             menu.addAction(load_action)
 
         menu.addSeparator()
         set_hotkey_action = QAction("Set Hotkey", menu)
-        set_hotkey_action.triggered.connect(self._on_set_hotkey)
+        set_hotkey_action.triggered.connect(partial(self._on_set_hotkey, menu))
         if self._loaded_config_abspath:
             set_hotkey_action.setText(f"Set Hotkey for {os.path.split(self._loaded_config_abspath)[1]}")
         else:
             set_hotkey_action.setDisabled(True)
         menu.addAction(set_hotkey_action)
 
-    def _on_set_hotkey(self) -> None:
+    def _on_set_hotkey(self, parent: QWidget) -> None:
         assert self._loaded_config_abspath  # shouldn't be triggerable unless something loaded
         recents = self._get_recents()
 
-        hotkey, ok = QInputDialog.getInt(self, "Set Hotkey Slot", "", value=0, minValue=0, maxValue=9)
+        hotkey, ok = QInputDialog.getInt(parent, "Set Hotkey Slot", "", value=0, minValue=0, maxValue=9)
         if not ok:
             return
 
         if self._loaded_config_abspath in recents.recents:
             recents.recents.remove(self._loaded_config_abspath)
         recents.hotkeys[hotkey] = self._loaded_config_abspath
-        self._RECENTS_SETTINGS.setValue(self._RECENTS_CONFIG_KEY, yaml.dump(recents.model_dump(), sort_keys=False))
+        self._settings.setValue(self._config_key, yaml.dump(recents.model_dump(), sort_keys=False))
 
     def _load_hotkey_slot(self, slot: int) -> None:
         recents = self._get_recents()
         target = recents.hotkeys.get(slot, None)
         if target is not None:
-            self.load_config_file(target)
+            self._load_fn(target)
 
-    def _append_recent(self, filename: str) -> None:
+    def append_recent(self, filename: str) -> None:
         recents = self._get_recents()
         if self._loaded_config_abspath in recents.hotkeys.values():
             return  # don't overwrite hotkeys
@@ -95,4 +98,4 @@ class BaseRecents(QWidget):
         if excess_recents > 0:
             recents.recents = recents.recents[:-excess_recents]
 
-        self._RECENTS_SETTINGS.setValue(self._RECENTS_CONFIG_KEY, yaml.dump(recents.model_dump(), sort_keys=False))
+        self._settings.setValue(self._config_key, yaml.dump(recents.model_dump(), sort_keys=False))


### PR DESCRIPTION
Creates a separate RecentsManager class, which encapsulates the recents functionality (serialization, menu population) into its own class and makes it available as part of the API.

Also, moves the save-restore functionality from the CSV viewer into PlotsTableWidget, enabling other subclasses to use the save/load config code.