### PR TITLE
Allow point sizing for refgeo scatter

### DIFF
--- a/pyqtgraph_scope_plots/xy_plot_refgeo.py
+++ b/pyqtgraph_scope_plots/xy_plot_refgeo.py
@@ -202,7 +202,7 @@ class XyRefGeoScatter(XyRefGeoBasePoints):
             raise TypeError("unknown marker type")
         scatter = pg.ScatterPlotItem(x=xs, y=ys, pen=color, brush=color, symbol=pg_symbol)
         if self._s is not None:
-            scatter.setSize(self._s)
+            scatter.setSize(self._s)  # pyqtgraph exceptions if s is array but of wrong length
         return [scatter]
 
 


### PR DESCRIPTION
Uses matplotlib style argument name. Supports both single value (for all points) as well as array (for point-by-point).