### PR TITLE
Add pandas_read_csv_kwargs argument to csv viewer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pyqtgraph-scope-plots"
 description = "Scope like plot utilities for pyqtgraph"
 readme = "README.md"
-version = "1.5.4"
+version = "1.5.5"
 authors = [
     { name = "Richard Lin", email = "richardlin@enphaseenergy.com" }
 ]

--- a/pyqtgraph_scope_plots/csv/__main__.py
+++ b/pyqtgraph_scope_plots/csv/__main__.py
@@ -64,4 +64,5 @@ if __name__ == "__main__":
     )
 
     plots.show()
+    plots._plots.autorange(True)
     app.exec()

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -371,6 +371,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         append: bool = False,
         colnames: Optional[Iterable[str]] = None,
         update: bool = True,
+        pandas_read_csv_kwargs: Dict[str, str] = {},
     ) -> "CsvLoaderPlotsTableWidget":
         """Loads CSV files into the current window.
         If append is true, preserves the existing data / metadata.
@@ -393,10 +394,16 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
                 data_dict[data_name] = (np.array([]), np.array([]))
                 assert data_name in data_type_dict  # keeps prior value
 
+        # preprocess arguments
+        if "engine" not in pandas_read_csv_kwargs:
+            pandas_read_csv_kwargs["engine"] = "pyarrow"  # faster
+        if "on_bad_lines" not in pandas_read_csv_kwargs:
+            pandas_read_csv_kwargs["on_bad_lines"] = "warn"
+
         # read through CSVs
         any_is_timevalue = False
         for csv_filepath in csv_filepaths:
-            df = pd.read_csv(csv_filepath)
+            df = pd.read_csv(csv_filepath, **pandas_read_csv_kwargs)
             self._csv_time[csv_filepath] = time.time()
 
             time_values = df[df.columns[0]]

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -331,6 +331,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         if not csv_filenames:  # nothing selected, user canceled
             return
         self._load_csvs(csv_filenames)
+        self._plots.autorange(True)
 
     def _on_append_csv(self) -> None:
         csv_filenames, _ = QFileDialog.getOpenFileNames(None, "Select CSV Files", filter="CSV files (*.csv)")

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -191,13 +191,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         self, x_axis: Optional[Callable[[], pg.AxisItem]] = None, pandas_read_csv_kwargs: Dict[str, Any] = {}
     ) -> None:
         self._x_axis = x_axis
-
-        # preprocess arguments
         self._pandas_read_csv_kwargs = pandas_read_csv_kwargs.copy()
-        if "engine" not in self._pandas_read_csv_kwargs:
-            self._pandas_read_csv_kwargs["engine"] = "pyarrow"  # faster
-        if "on_bad_lines" not in self._pandas_read_csv_kwargs:
-            self._pandas_read_csv_kwargs["on_bad_lines"] = "warn"
 
         super().__init__()
 

--- a/pyqtgraph_scope_plots/csv/csv_plots.py
+++ b/pyqtgraph_scope_plots/csv/csv_plots.py
@@ -371,7 +371,7 @@ class CsvLoaderPlotsTableWidget(AnimationPlotsTableWidget, PlotsTableWidget, Has
         append: bool = False,
         colnames: Optional[Iterable[str]] = None,
         update: bool = True,
-        pandas_read_csv_kwargs: Dict[str, str] = {},
+        pandas_read_csv_kwargs: Dict[str, Any] = {},
     ) -> "CsvLoaderPlotsTableWidget":
         """Loads CSV files into the current window.
         If append is true, preserves the existing data / metadata.

--- a/pyqtgraph_scope_plots/enum_waveform_plotitem.py
+++ b/pyqtgraph_scope_plots/enum_waveform_plotitem.py
@@ -13,7 +13,7 @@
 #    limitations under the License.
 
 import bisect
-from typing import List, Tuple, Optional, Any, cast, Sequence, Mapping
+from typing import List, Tuple, Optional, Any, cast, Mapping
 
 import numpy as np
 import numpy.typing as npt


### PR DESCRIPTION
Allows the user to, for example, use the much faster PyArrow. Not set by default since it requires another dependency.

Also adds auto-ranging on CSV load, which broke with an earlier PR.

