### PR TITLE
Iterate across items of dataframe in preprocessing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pyqtgraph-scope-plots"
 description = "Scope like plot utilities for pyqtgraph"
 readme = "README.md"
-version = "1.5.6"
+version = "1.5.5"
 authors = [
     { name = "Richard Lin", email = "richardlin@enphaseenergy.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pyqtgraph-scope-plots"
 description = "Scope like plot utilities for pyqtgraph"
 readme = "README.md"
-version = "1.5.5"
+version = "1.5.6"
 authors = [
     { name = "Richard Lin", email = "richardlin@enphaseenergy.com" }
 ]


### PR DESCRIPTION
This better handles (as in not crashes) when there are duplicate col names, which otherwise would return both columns when indexing `df[col_name]`. This will discard duplicate cols.

Also fixes init API to only take pandas read csv kwargs as a kwarg