### PR TITLE
Improve enum edge detection efficiency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pyqtgraph-scope-plots"
 description = "Scope like plot utilities for pyqtgraph"
 readme = "README.md"
-version = "1.5.5"
+version = "1.5.6"
 authors = [
     { name = "Richard Lin", email = "richardlin@enphaseenergy.com" }
 ]

--- a/pyqtgraph_scope_plots/enum_waveform_plotitem.py
+++ b/pyqtgraph_scope_plots/enum_waveform_plotitem.py
@@ -80,7 +80,7 @@ class EnumWaveformPlot(SnappableHoverPlot, HasDataValueAt, DataPlotItem):
         # do change detection to find edges, element is true if it is different from the next element
         if len(data.ys):
             # prechanges is true on the index before the change
-            prechanges = np.not_equal(data.ys, np.append(data.ys[1:], data.ys[-1]))
+            prechanges = np.not_equal(ys_int[:-1], ys_int[1:])
         else:  # handle empty array case
             prechanges = np.array([])
 


### PR DESCRIPTION
It wasn't using the last element anyways, this truncates one of the input arrays instead of padding it. Also reverts to using the integer-ized data, instead of the original strings. Theoretically a slight performance gain.