### PR TITLE
Interactivity optimization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pyqtgraph-scope-plots"
 description = "Scope like plot utilities for pyqtgraph"
 readme = "README.md"
-version = "1.5.6"
+version = "1.5.7"
 authors = [
     { name = "Richard Lin", email = "richardlin@enphaseenergy.com" }
 ]

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -18,16 +18,15 @@ live x-axis cursor, region selection, and points-of-interest.
 """
 
 import bisect
-import math
 from abc import abstractmethod
 from typing import List, Tuple, Dict, Optional, Any, cast, NamedTuple, Union, Mapping
 
 import numpy as np
-from numpy import typing as npt
 import pyqtgraph as pg
 from PySide6.QtCore import QPointF, QSignalBlocker, Signal, Slot
 from PySide6.QtGui import Qt, QColor, QKeyEvent
 from PySide6.QtWidgets import QGraphicsSceneMouseEvent
+from numpy import typing as npt
 from pyqtgraph import mkPen
 from pyqtgraph.GraphicsScene.mouseEvents import HoverEvent
 

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -160,9 +160,8 @@ class SnappableHoverPlot(DataPlotCurveItem):
                 continue
 
             # this code inspired by ScatterPlotItem._maskAt, which is used to find intersecting items fast
-            # account for graph scaling
-            px, py = data_graphics[0].pixelVectors()
-            if px is None or py is None or px == 0 or py == 0:  # invalid
+            px, py = data_graphics[0].pixelVectors()  # account for graph scaling
+            if px is None or py is None or px.x() == 0 or py.y() == 0:  # invalid
                 continue
             dxs = (data.xs[index_lo:index_hi] - target_pos.x()) / px.x()
             dys = (data.ys[index_lo:index_hi] - target_pos.y()) / py.y()

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -99,20 +99,21 @@ def test_plot_restore(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     plot._plots._load_model(model)
     plot._plots.set_data(plot._plots._data)  # bulk update that happens at top level
     qtbot.waitUntil(lambda: plot._plots.count() == 1)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 3
+    # +1 is for the empty hover scatterpoints
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 3 + 1
 
     model.plot_widgets = [PlotWidgetModel(data_items=["0"]), PlotWidgetModel(data_items=["2"])]
     plot._plots._load_model(model)
     plot._plots.set_data(plot._plots._data)  # bulk update that happens at top level
     qtbot.waitUntil(lambda: plot._plots.count() == 2)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 1
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(1)).getPlotItem()).listDataItems()) == 1
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 1 + 1
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(1)).getPlotItem()).listDataItems()) == 1 + 1
 
     model.plot_widgets = []  # test empty case
     plot._plots._load_model(model)
     plot._plots.set_data(plot._plots._data)  # bulk update that happens at top level
     qtbot.waitUntil(lambda: plot._plots.count() == 1)  # should leave the empty widget intact
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 0
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 0 + 1
 
 
 def test_plot_restore_range(qtbot: QtBot, plot: PlotsTableWidget) -> None:
@@ -157,7 +158,8 @@ def test_no_excessive_plots(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     )
 
     qtbot.waitUntil(lambda: plot._plots.count() == 1)  # should just create an empty plot
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 0
+    # +1 is for the empty hover scatterpoints
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem()).listDataItems()) == 0 + 1
 
 
 def test_export_csv(qtbot: QtBot, plot: PlotsTableWidget) -> None:

--- a/tests/test_droppable_plot.py
+++ b/tests/test_droppable_plot.py
@@ -44,8 +44,9 @@ def test_plot_merge(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None:
 
     plots._merge_data_into_item(["0"], 1)  # merge
     qtbot.waitUntil(lambda: plots.count() == 2)  # wait for widgets to merge
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 2
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 1
+    # +1 is for the empty hover scatterpoints
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 2 + 1
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 1 + 1
     assert table.rowCount() == 3  # signals table should not change
     assert table.item(0, table.COL_NAME).text() == "0"
     assert table.item(1, table.COL_NAME).text() == "1"
@@ -53,8 +54,8 @@ def test_plot_merge(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None:
 
     plots._merge_data_into_item(["0"], 1)  # move
     qtbot.waitUntil(lambda: plots.count() == 2)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 1
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 2
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 1 + 1
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 2 + 1
     assert table.rowCount() == 3  # signals table should not change
     assert table.item(0, table.COL_NAME).text() == "0"
     assert table.item(1, table.COL_NAME).text() == "1"
@@ -62,7 +63,7 @@ def test_plot_merge(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None:
 
     plots._merge_data_into_item(["1"], 1)  # merge all
     qtbot.waitUntil(lambda: plots.count() == 1)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 3
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 3 + 1
     assert table.rowCount() == 3  # signals table should not change
     assert table.item(0, table.COL_NAME).text() == "0"
     assert table.item(1, table.COL_NAME).text() == "1"
@@ -84,21 +85,22 @@ def test_plot_merge_multi(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None
 
     plots._merge_data_into_item(["0", "1"], 0)  # merge into self, including self
     qtbot.waitUntil(lambda: plots.count() == 2)  # wait for widgets to merge
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 2
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 1
+    # +1 is for the empty hover scatterpoints
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 2 + 1
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 1 + 1
 
     plots._merge_data_into_item(["0", "1"], 1)  # merge into other, not including self
     qtbot.waitUntil(lambda: plots.count() == 1)  # wait for widgets to merge
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 3
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 3 + 1
 
     plots._merge_data_into_item(["1", "2"], 2, insert=True)  # insert at bottom
     qtbot.waitUntil(lambda: plots.count() == 2)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 1
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 2
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 1 + 1
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(1)).getPlotItem()).listDataItems()) == 2 + 1
 
     plots._merge_data_into_item(["0", "1", "2"], 2, insert=True)  # insert all
     qtbot.waitUntil(lambda: plots.count() == 1)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 3
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 3 + 1
 
 
 def test_invalid_plot_merge(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None:
@@ -126,16 +128,17 @@ def test_plot_remove(qtbot: QtBot, plots: DroppableMultiPlotWidget) -> None:
 
     plots._merge_data_into_item(["2"], 0)  # merge all into top
     qtbot.waitUntil(lambda: plots.count() == 1)
-    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 2
+    # +1 is for the empty hover scatterpoints
+    assert len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 2 + 1
 
     plots.remove_plot_items(["0"])
     qtbot.waitUntil(
-        lambda: len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 1
+        lambda: len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 1 + 1
     )
 
     plots.remove_plot_items(["2"])  # delete the last plot, the empty plot should appear
     qtbot.waitUntil(
-        lambda: len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 0
+        lambda: len(cast(pg.PlotItem, cast(pg.PlotWidget, plots.widget(0)).getPlotItem()).listDataItems()) == 0 + 1
     )
 
 


### PR DESCRIPTION
Two optimizations that significantly improves performance (tens of ms) for large data sets:
- Change mouseover points to use one ScatterPlotItem per graph widget instead of per data set, which reduces per-ScatterPlotItem overhead.
- Vectorize the hover snap point detection and increase the max points window now that it is much faster.