### PR TITLE
Re-use scatterplot and textitems for efficiency

### DIFF
--- a/pyqtgraph_scope_plots/graphics_collections.py
+++ b/pyqtgraph_scope_plots/graphics_collections.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Enphase Energy, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+"""Wrapper classes for collections of graphical objects."""
+from typing import List, Tuple, Optional
+
+import pyqtgraph as pg
+from PySide6.QtCore import QPointF
+from PySide6.QtGui import QColor
+
+
+class TextItemCollection:
+    """Maintains a pool of TextItems that persist across refreshes (for efficiency)"""
+
+    def __init__(
+        self, parent: pg.PlotItem, *, anchor: Optional[Tuple[float, float]] = None, z_value: Optional[float] = None
+    ) -> None:
+        self._parent = parent
+        self._anchor = anchor
+        self._z_value = z_value
+
+        self._labels: List[pg.TextItem] = []
+
+    def update(self, pts: List[Tuple[float, float, str, QColor]]) -> None:
+        for _ in range(len(self._labels), len(pts)):
+            label = pg.TextItem("")
+            if self._anchor is not None:
+                label.setAnchor(self._anchor)
+            if self._z_value is not None:
+                label.setZValue(self._z_value)
+            self._parent.addItem(label, ignoreBounds=True)
+            self._labels.append(label)
+        for _ in reversed(range(len(pts), len(self._labels))):
+            self._parent.removeItem(self._labels.pop())
+        for text_item, (x_pos, y_pos, text, color) in zip(self._labels, pts):
+            text_item.setPos(QPointF(x_pos, y_pos))
+            text_item.setText(text)
+            text_item.setColor(color)
+
+
+class ScatterItemCollection:
+    """Presents a unified API drawing multiple points into a single scatterplot (for efficiency)"""
+
+    def __init__(self, parent: pg.PlotItem, *, z_value: Optional[float] = None) -> None:
+        self._scatter = pg.ScatterPlotItem(x=[], y=[], symbol="o")
+        if z_value is not None:
+            self._scatter.setZValue(z_value)
+        parent.addItem(self._scatter, ignoreBounds=True)
+
+    def update(self, pts: List[Tuple[float, float, QColor]]) -> None:
+        if len(pts) > 0:  # convert the list-of-tuples into a lists of point values for scatterplot format
+            x_poss, y_poss, colors = tuple(map(list, zip(*pts)))
+        else:  # zip returns empty for empty inputs
+            x_poss, y_poss, colors = [], [], []
+        self._scatter.setData(x=x_poss, y=y_poss, brush=colors)

--- a/pyqtgraph_scope_plots/graphics_collections.py
+++ b/pyqtgraph_scope_plots/graphics_collections.py
@@ -42,6 +42,7 @@ class TextItemCollection:
             self._labels.append(label)
         for _ in reversed(range(len(pts), len(self._labels))):
             self._parent.removeItem(self._labels.pop())
+        assert len(self._labels) == len(pts)
         for text_item, (x_pos, y_pos, text, color) in zip(self._labels, pts):
             text_item.setPos(QPointF(x_pos, y_pos))
             text_item.setText(text)

--- a/pyqtgraph_scope_plots/graphics_collections.py
+++ b/pyqtgraph_scope_plots/graphics_collections.py
@@ -47,15 +47,21 @@ class TextItemCollection:
             text_item.setText(text)
             text_item.setColor(color)
 
+    def remove(self) -> None:
+        """Removes all labels from the container. Call before this item is deleted."""
+        while len(self._labels):
+            self._parent.removeItem(self._labels.pop())
+
 
 class ScatterItemCollection:
     """Presents a unified API drawing multiple points into a single scatterplot (for efficiency)"""
 
     def __init__(self, parent: pg.PlotItem, *, z_value: Optional[float] = None) -> None:
+        self._parent = parent
         self._scatter = pg.ScatterPlotItem(x=[], y=[], symbol="o")
         if z_value is not None:
             self._scatter.setZValue(z_value)
-        parent.addItem(self._scatter, ignoreBounds=True)
+        self._parent.addItem(self._scatter, ignoreBounds=True)
 
     def update(self, pts: List[Tuple[float, float, QColor]]) -> None:
         if len(pts) > 0:  # convert the list-of-tuples into a lists of point values for scatterplot format
@@ -63,3 +69,7 @@ class ScatterItemCollection:
         else:  # zip returns empty for empty inputs
             x_poss, y_poss, colors = [], [], []
         self._scatter.setData(x=x_poss, y=y_poss, brush=colors)
+
+    def remove(self) -> None:
+        """Removes all labels from the container. Call before this item is deleted."""
+        self._parent.removeItem(self._scatter)

--- a/pyqtgraph_scope_plots/graphics_collections.py
+++ b/pyqtgraph_scope_plots/graphics_collections.py
@@ -40,7 +40,7 @@ class TextItemCollection:
                 label.setZValue(self._z_value)
             self._parent.addItem(label, ignoreBounds=True)
             self._labels.append(label)
-        for _ in reversed(range(len(pts), len(self._labels))):
+        for _ in range(len(pts), len(self._labels)):
             self._parent.removeItem(self._labels.pop())
         assert len(self._labels) == len(pts)
         for text_item, (x_pos, y_pos, text, color) in zip(self._labels, pts):

--- a/pyqtgraph_scope_plots/graphics_collections.py
+++ b/pyqtgraph_scope_plots/graphics_collections.py
@@ -71,5 +71,5 @@ class ScatterItemCollection:
         self._scatter.setData(x=x_poss, y=y_poss, brush=colors)
 
     def remove(self) -> None:
-        """Removes all labels from the container. Call before this item is deleted."""
+        """Removes the scatter points from the container. Call before this item is deleted."""
         self._parent.removeItem(self._scatter)

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -569,6 +569,7 @@ class PointsOfInterestPlot(SnappableHoverPlot, HasDataValueAt):
         for poi, pos in zip(self.pois, pois):
             poi.setPos(pos)
             self._update_poi(poi)
+        self.sigPoiChanged.emit([poi.x() for poi in self.pois])
 
     def _on_poi_drag(self, cursor: pg.InfiniteLine) -> None:
         if self.hover_snap_point.snap_pos is not None:
@@ -604,16 +605,14 @@ class PointsOfInterestPlot(SnappableHoverPlot, HasDataValueAt):
         self.pois.append(cursor)
         self._poi_items[cursor] = (ScatterItemCollection(self), TextItemCollection(self, anchor=self.POI_ANCHOR))
         self._update_poi(cursor)
-        self.sigPoiChanged.emit([poi.x() for poi in self.pois])
 
-    def _remove_poi(self, cursor: pg.InfiniteLine):
+    def _remove_poi(self, cursor: pg.InfiniteLine) -> None:
         scatter, texts = self._poi_items[cursor]
         scatter.remove()
         texts.remove()
         del self._poi_items[cursor]
         self.pois.remove(cursor)
         self.removeItem(cursor)
-        self.sigPoiChanged.emit([poi.x() for poi in self.pois])
 
     def mouseDoubleClickEvent(self, event: QGraphicsSceneMouseEvent) -> None:
         super().mouseDoubleClickEvent(event)
@@ -627,6 +626,7 @@ class PointsOfInterestPlot(SnappableHoverPlot, HasDataValueAt):
 
         if create_pos.x() not in [poi.pos().x() for poi in self.pois]:  # don't duplicate
             self._add_poi(create_pos.x())
+            self.sigPoiChanged.emit([poi.x() for poi in self.pois])
 
     def keyPressEvent(self, ev: QKeyEvent) -> None:
         super().keyPressEvent(ev)
@@ -634,6 +634,7 @@ class PointsOfInterestPlot(SnappableHoverPlot, HasDataValueAt):
             for poi in reversed(self.pois):
                 if poi.mouseHovering:
                     self._remove_poi(poi)
+            self.sigPoiChanged.emit([poi.x() for poi in self.pois])
 
 
 class DraggableCursorPlot(SnappableHoverPlot, HasDataValueAt):

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -566,6 +566,7 @@ class PointsOfInterestPlot(SnappableHoverPlot, HasDataValueAt):
             self._add_poi(0)
         for _ in range(len(pois), len(self.pois)):  # POIs to be removed
             self._remove_poi(self.pois[-1])
+        assert len(self.pois) == len(pois)
         for poi, pos in zip(self.pois, pois):
             poi.setPos(pos)
             self._update_poi(poi)

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -557,72 +557,62 @@ class PointsOfInterestPlot(SnappableHoverPlot, HasDataValueAt):
         super().__init__(*args, **kwargs)
 
         self.pois: List[pg.InfiniteLine] = []  # lines
-        self._poi_items: Dict[pg.InfiniteLine, List[Union[pg.GraphicsObject]]] = {}
+        self._poi_items: Dict[pg.InfiniteLine, Tuple[ScatterItemCollection, TextItemCollection]] = {}
 
         self.sigRangeChanged.connect(self._update_all_poi_labels)
 
     def set_pois(self, pois: List[float]) -> None:
-        for poi, items in self._poi_items.items():
-            self.removeItem(poi)
-            for item in items:
-                self.removeItem(item)
-        self.pois = []
-        self._poi_items = {}
-
-        for poi in pois:
-            self._add_poi(poi)
+        for _ in range(len(self.pois), len(pois)):  # POIs to be added
+            self._add_poi(0)
+        for _ in range(len(pois), len(self.pois)):  # POIs to be removed
+            self._remove_poi(self.pois[-1])
+        for poi, pos in zip(self.pois, pois):
+            poi.setPos(pos)
+            self._update_poi(poi)
 
     def _on_poi_drag(self, cursor: pg.InfiniteLine) -> None:
         if self.hover_snap_point.snap_pos is not None:
             cursor.setPos(self.hover_snap_point.snap_pos)
-        for item in self._poi_items[cursor]:
-            self.removeItem(item)
-        self._poi_items[cursor] = []
-        self._generate_poi_items(cursor)
+        self._update_poi(cursor)
         self.sigPoiChanged.emit([poi.x() for poi in self.pois])
 
-    def _generate_poi_items(self, cursor: pg.InfiniteLine) -> None:
-        for y_pos, text, color in self._data_value_label_at(cursor.x(), precision_factor=0.1):
-            poi_pt = pg.ScatterPlotItem(x=[cursor.x()], y=[y_pos], symbol="o", brush=color)
-            self.addItem(poi_pt, ignoreBounds=True)
-            self._poi_items[cursor].append(poi_pt)
-            y_label = pg.TextItem(anchor=self.POI_ANCHOR)
-            y_label.setPos(QPointF(cursor.x(), y_pos))
-            y_label.setText(text)
-            y_label.setColor(color)
-            self.addItem(y_label, ignoreBounds=True)
-            self._poi_items[cursor].append(y_label)
+    def _update_poi(self, cursor: pg.InfiniteLine) -> None:
+        scatter, texts = self._poi_items[cursor]
+        x_y_text_color = [
+            (cursor.x(), y_pos, text, color)
+            for y_pos, text, color in self._data_value_label_at(cursor.x(), precision_factor=0.1)
+        ]
+        scatter.update([(x_pos, y_pos, color) for x_pos, y_pos, text, color in x_y_text_color])
+        texts.update(x_y_text_color)
 
     @Slot()
     def _update_all_poi_labels(self) -> None:
         """Regenerate text for all POI labels, eg to account for scale changes"""
-        for line, items in self._poi_items.items():
-            for item in items:
-                self.removeItem(item)
-            self._poi_items[line] = []
-            self._generate_poi_items(line)
+        for line, _ in self._poi_items.items():
+            self._update_poi(line)
 
-    def addItem(self, item: Any, *args: Any, **kargs: Any) -> None:
-        super().addItem(item, *args, **kargs)
-        if isinstance(item, pg.PlotCurveItem):  # update labels if plot changed
-            self._update_all_poi_labels()
-
-    def removeItem(self, item: Any) -> None:
-        super().removeItem(item)
-        if isinstance(item, pg.PlotCurveItem):  # update labels if plot changed
-            self._update_all_poi_labels()
+    def set_data(self, *args: Any, **kwargs: Any) -> None:
+        super().set_data(*args, **kwargs)
+        self._update_all_poi_labels()  # update if plot changed
 
     def _add_poi(self, pos: float) -> None:
-        if pos in [cursor.pos().x() for cursor in self.pois]:
-            return  # don't double-create
-
+        """Adds a new POI at the location"""
         cursor = pg.InfiniteLine(movable=True)
         cursor.setPos((pos, 0))
         cursor.sigDragged.connect(self._on_poi_drag)
         self.addItem(cursor, ignoreBounds=True)
         self.pois.append(cursor)
-        self._poi_items[cursor] = []
-        self._generate_poi_items(cursor)
+        self._poi_items[cursor] = (ScatterItemCollection(self), TextItemCollection(self, anchor=self.POI_ANCHOR))
+        self._update_poi(cursor)
+        self.sigPoiChanged.emit([poi.x() for poi in self.pois])
+
+    def _remove_poi(self, cursor: pg.InfiniteLine):
+        scatter, texts = self._poi_items[cursor]
+        scatter.remove()
+        texts.remove()
+        del self._poi_items[cursor]
+        self.pois.remove(cursor)
+        self.removeItem(cursor)
         self.sigPoiChanged.emit([poi.x() for poi in self.pois])
 
     def mouseDoubleClickEvent(self, event: QGraphicsSceneMouseEvent) -> None:
@@ -634,23 +624,16 @@ class PointsOfInterestPlot(SnappableHoverPlot, HasDataValueAt):
             create_pos = self.hover_snap_point.snap_pos
         else:
             create_pos = self.hover_snap_point.hover_pos
-        self._add_poi(create_pos.x())
+
+        if create_pos.x() not in [poi.pos().x() for poi in self.pois]:  # don't duplicate
+            self._add_poi(create_pos.x())
 
     def keyPressEvent(self, ev: QKeyEvent) -> None:
         super().keyPressEvent(ev)
         if ev.key() == Qt.Key.Key_Delete:
-            deleted = False
             for poi in reversed(self.pois):
                 if poi.mouseHovering:
-                    if poi in self._poi_items:
-                        for item in self._poi_items[poi]:
-                            self.removeItem(item)
-                        del self._poi_items[poi]
-                    self.pois.remove(poi)
-                    self.removeItem(poi)
-                    deleted = True
-            if deleted:
-                self.sigPoiChanged.emit([poi.x() for poi in self.pois])
+                    self._remove_poi(poi)
 
 
 class DraggableCursorPlot(SnappableHoverPlot, HasDataValueAt):

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -269,11 +269,10 @@ class LiveCursorPlot(SnappableHoverPlot, HasDataValueAt):
 
             y_text_colors = []
 
-        # convert the list-of-tuples into a lists of point values for scatterplot format
-        if len(y_text_colors) > 0:
+        if len(y_text_colors) > 0:  # convert the list-of-tuples into a lists of point values for scatterplot format
             x_poss = [pos] * len(y_text_colors)
             y_poss, _, colors = tuple(map(list, zip(*y_text_colors)))
-        else:
+        else:  # zip returns empty for empty inputs
             x_poss, y_poss, colors = [], [], []
         self._hover_y_pts.setData(x=x_poss, y=y_poss, brush=colors)
 

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -229,13 +229,13 @@ class LiveCursorPlot(SnappableHoverPlot, HasDataValueAt):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-        self.hover_cursor = pg.InfiniteLine(
+        self._hover_cursor = pg.InfiniteLine(
             angle=90,
             movable=False,
             pen=mkPen(style=Qt.PenStyle.DotLine),
         )  # moves with hover not drag
-        self.hover_cursor.hide()
-        self.addItem(self.hover_cursor, ignoreBounds=True)
+        self._hover_cursor.hide()
+        self.addItem(self._hover_cursor, ignoreBounds=True)
 
         self._hover_x_label = pg.TextItem(anchor=self.LIVE_CURSOR_X_ANCHOR)
         self._hover_x_label.hide()
@@ -254,8 +254,8 @@ class LiveCursorPlot(SnappableHoverPlot, HasDataValueAt):
         If a y position is specified, draws the time label there, otherwise no time label.
         """
         if pos is not None:  # create or update live cursor
-            self.hover_cursor.setPos(pos)
-            self.hover_cursor.show()
+            self._hover_cursor.setPos(pos)
+            self._hover_cursor.show()
 
             if pos_y is not None:
                 self._hover_x_label.setPos(QPointF(pos, pos_y))  # y follows mouse, x is at cursor
@@ -268,7 +268,7 @@ class LiveCursorPlot(SnappableHoverPlot, HasDataValueAt):
                 (pos, y_pos, text, color) for y_pos, text, color in self._data_value_label_at(pos, precision_factor=0.1)
             ]
         else:  # delete live cursor
-            self.hover_cursor.hide()
+            self._hover_cursor.hide()
             self._hover_x_label.hide()
 
             x_y_text_colors = []

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -241,7 +241,7 @@ class XyPlotLinkedPoiWidget(XyPlotWidget):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         assert isinstance(self._plots, LinkedMultiPlotWidget)
-        self._poi_pts: List[pg.ScatterPlotItem] = []
+        self._poi_pts = ScatterItemCollection(self, z_value=LiveCursorPlot._Z_VALUE_HOVER_TARGET)
 
         self._plots.sigPoiChanged.connect(self._on_linked_poi_change)
 
@@ -251,15 +251,11 @@ class XyPlotLinkedPoiWidget(XyPlotWidget):
 
     def _on_linked_poi_change(self) -> None:
         assert isinstance(self._plots, LinkedMultiPlotWidget)
-        for pts in self._poi_pts:  # clear old widgets as needed, then re-create
-            self.removeItem(pts)
-        self._poi_pts = []
 
+        all_x_y_colors = []
         for t in self._plots._last_pois:
-            for x, y, color in self._get_visible_xys_at_t(t):
-                poi_pt = pg.ScatterPlotItem(x=[x], y=[y], symbol="o", brush=color)
-                self.addItem(poi_pt, ignoreBounds=True)
-                self._poi_pts.append(poi_pt)
+            all_x_y_colors.extend(self._get_visible_xys_at_t(t))
+        self._poi_pts.update(all_x_y_colors)
 
 
 class XyDragDroppable(BaseXyPlot):

--- a/pyqtgraph_scope_plots/xy_plot.py
+++ b/pyqtgraph_scope_plots/xy_plot.py
@@ -23,6 +23,7 @@ from PySide6.QtWidgets import QMessageBox, QWidget, QTableWidgetItem, QMenu
 from numpy import typing as npt
 from pydantic import BaseModel
 
+from .graphics_collections import ScatterItemCollection
 from .interactivity_mixins import LiveCursorPlot
 from .multi_plot_widget import DragTargetOverlay, MultiPlotWidget, LinkedMultiPlotWidget
 from .util import HasSaveLoadConfig, MixinColsTable
@@ -219,9 +220,7 @@ class XyPlotLinkedCursorWidget(XyPlotWidget):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         assert isinstance(self._plots, LinkedMultiPlotWidget)
-        self._hover_pts = pg.ScatterPlotItem(x=[], y=[], symbol="o")
-        self._hover_pts.setZValue(LiveCursorPlot._Z_VALUE_HOVER_TARGET)
-        self.addItem(self._hover_pts, ignoreBounds=True)
+        self._hover_pts = ScatterItemCollection(self, z_value=LiveCursorPlot._Z_VALUE_HOVER_TARGET)
 
         self._plots.sigHoverCursorChanged.connect(self._on_linked_hover_cursor_change)
 
@@ -235,12 +234,7 @@ class XyPlotLinkedCursorWidget(XyPlotWidget):
         t = self._plots._last_hover
         if t is None:
             return
-        x_y_colors = self._get_visible_xys_at_t(t)
-        if len(x_y_colors) > 0:  # convert the list-of-tuples into a lists of point values for scatterplot format
-            x_poss, y_poss, colors = tuple(map(list, zip(*x_y_colors)))
-        else:  # zip returns empty for empty inputs
-            x_poss, y_poss, colors = [], [], []
-        self._hover_pts.setData(x=x_poss, y=y_poss, brush=colors)
+        self._hover_pts.update(self._get_visible_xys_at_t(t))
 
 
 class XyPlotLinkedPoiWidget(XyPlotWidget):

--- a/tests/test_linked_plot.py
+++ b/tests/test_linked_plot.py
@@ -25,17 +25,18 @@ def test_linked_live_cursor(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     """This (and subsequent) tests use internal APIs to set cursor positions and whatnot
     because these APIs are much more reliable than using QtBot mouse actions."""
     for i in range(3):
-        assert plot_item(plot, i).hover_cursor is None  # verify initial state
+        assert not plot_item(plot, i).hover_cursor.isVisible()  # verify initial state
 
     plot_item(plot, 0).set_live_cursor(0.1)
     qtbot.waitSignal(plot._plots.sigHoverCursorChanged)
-    qtbot.waitUntil(lambda: not_none(plot_item(plot, 1).hover_cursor).x() == 0.1)
+    qtbot.waitUntil(lambda: plot_item(plot, 1).hover_cursor.isVisible())
+    assert plot_item(plot, 1).hover_cursor.x() == 0.1
     assert not_none(plot_item(plot, 2).hover_cursor).x() == 0.1
 
     plot_item(plot, 1).set_live_cursor(None)
     qtbot.waitSignal(plot._plots.sigHoverCursorChanged)
-    qtbot.waitUntil(lambda: plot_item(plot, 0).hover_cursor is None)
-    assert plot_item(plot, 2).hover_cursor is None
+    qtbot.waitUntil(lambda: not plot_item(plot, 0).hover_cursor.isVisible())
+    qtbot.waitUntil(lambda: not plot_item(plot, 2).hover_cursor.isVisible())
 
 
 def test_linked_region(qtbot: QtBot, plot: PlotsTableWidget) -> None:

--- a/tests/test_linked_plot.py
+++ b/tests/test_linked_plot.py
@@ -25,18 +25,18 @@ def test_linked_live_cursor(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     """This (and subsequent) tests use internal APIs to set cursor positions and whatnot
     because these APIs are much more reliable than using QtBot mouse actions."""
     for i in range(3):
-        assert not plot_item(plot, i).hover_cursor.isVisible()  # verify initial state
+        assert not plot_item(plot, i)._hover_cursor.isVisible()  # verify initial state
 
     plot_item(plot, 0).set_live_cursor(0.1)
     qtbot.waitSignal(plot._plots.sigHoverCursorChanged)
-    qtbot.waitUntil(lambda: plot_item(plot, 1).hover_cursor.isVisible())
-    assert plot_item(plot, 1).hover_cursor.x() == 0.1
-    assert not_none(plot_item(plot, 2).hover_cursor).x() == 0.1
+    qtbot.waitUntil(lambda: plot_item(plot, 1)._hover_cursor.isVisible())
+    assert plot_item(plot, 1)._hover_cursor.x() == 0.1
+    assert not_none(plot_item(plot, 2)._hover_cursor).x() == 0.1
 
     plot_item(plot, 1).set_live_cursor(None)
     qtbot.waitSignal(plot._plots.sigHoverCursorChanged)
-    qtbot.waitUntil(lambda: not plot_item(plot, 0).hover_cursor.isVisible())
-    qtbot.waitUntil(lambda: not plot_item(plot, 2).hover_cursor.isVisible())
+    qtbot.waitUntil(lambda: not plot_item(plot, 0)._hover_cursor.isVisible())
+    qtbot.waitUntil(lambda: not plot_item(plot, 2)._hover_cursor.isVisible())
 
 
 def test_linked_region(qtbot: QtBot, plot: PlotsTableWidget) -> None:

--- a/tests/test_plot_cursors.py
+++ b/tests/test_plot_cursors.py
@@ -147,7 +147,7 @@ def test_snap_gui(qtbot: QtBot) -> None:
             Qt.KeyboardModifier.NoModifier,
         )
     )
-    qtbot.waitUntil(lambda: plot_item.hover_cursor is None)
+    qtbot.waitUntil(lambda: not plot_item.hover_cursor.isVisible())
 
 
 def test_range_gui(qtbot: QtBot) -> None:

--- a/tests/test_plot_cursors.py
+++ b/tests/test_plot_cursors.py
@@ -112,7 +112,8 @@ def test_snap_gui(qtbot: QtBot) -> None:
             Qt.KeyboardModifier.NoModifier,
         )
     )
-    qtbot.waitUntil(lambda: not_none(plot_item._hover_target).pos() == QPointF(0.1, 1))
+    qtbot.waitUntil(lambda: plot_item._hover_target.isVisible())
+    assert plot_item._hover_target.pos() == QPointF(0.1, 1)
     assert not_none(plot_item.hover_snap_point.snap_pos) == QPointF(0.1, 1)
     assert [label.color for label in plot_item._hover_y_labels] == [QColor("yellow")]
     assert [label.toPlainText() for label in plot_item._hover_y_labels] == ["1.000"]  # single label only
@@ -129,7 +130,8 @@ def test_snap_gui(qtbot: QtBot) -> None:
             Qt.KeyboardModifier.NoModifier,
         )
     )
-    qtbot.waitUntil(lambda: not_none(plot_item._hover_target).pos() == QPointF(1, 0.25))
+    qtbot.waitUntil(lambda: plot_item._hover_target.isVisible())
+    assert plot_item._hover_target.pos() == QPointF(1, 0.25)
     assert not_none(plot_item.hover_snap_point.snap_pos) == QPointF(1, 0.25)
     assert plot_item.hover_cursor.pos().x() == 1
     assert [label.toPlainText() for label in plot_item._hover_y_labels] == ["1.000", "0.250", "0.600"]

--- a/tests/test_plot_cursors.py
+++ b/tests/test_plot_cursors.py
@@ -242,13 +242,13 @@ def test_poi_gui(qtbot: QtBot) -> None:
     )
     qtbot.waitUntil(lambda: len(plot_item.pois) == 1)
     assert plot_item.pois[0].pos().x() == 0
-    assert len(plot_item._poi_items[plot_item.pois[0]]) == 3 * 2
-    assert plot_item._poi_items[plot_item.pois[0]][1].toPlainText() == "0.010"
-    assert plot_item._poi_items[plot_item.pois[0]][1].color == QColor("yellow")
-    assert plot_item._poi_items[plot_item.pois[0]][3].toPlainText() == "0.500"
-    assert plot_item._poi_items[plot_item.pois[0]][3].color == QColor("orange")
-    assert plot_item._poi_items[plot_item.pois[0]][5].toPlainText() == "0.700"
-    assert plot_item._poi_items[plot_item.pois[0]][5].color == QColor("blue")
+    assert len(plot_item._poi_items[plot_item.pois[0]][1]._labels) == 3
+    assert plot_item._poi_items[plot_item.pois[0]][1]._labels[0].toPlainText() == "0.010"
+    assert plot_item._poi_items[plot_item.pois[0]][1]._labels[0].color == QColor("yellow")
+    assert plot_item._poi_items[plot_item.pois[0]][1]._labels[1].toPlainText() == "0.500"
+    assert plot_item._poi_items[plot_item.pois[0]][1]._labels[1].color == QColor("orange")
+    assert plot_item._poi_items[plot_item.pois[0]][1]._labels[2].toPlainText() == "0.700"
+    assert plot_item._poi_items[plot_item.pois[0]][1]._labels[2].color == QColor("blue")
 
     # must be near-exact
     qtbot.mouseClick(plot.viewport(), Qt.MouseButton.LeftButton, pos=data_to_screen(plot_item, 0, 0))  # force update

--- a/tests/test_plot_cursors.py
+++ b/tests/test_plot_cursors.py
@@ -133,7 +133,7 @@ def test_snap_gui(qtbot: QtBot) -> None:
     qtbot.waitUntil(lambda: plot_item._hover_target.isVisible())
     assert plot_item._hover_target.pos() == QPointF(1, 0.25)
     assert not_none(plot_item.hover_snap_point.snap_pos) == QPointF(1, 0.25)
-    assert plot_item.hover_cursor.pos().x() == 1
+    assert plot_item._hover_cursor.pos().x() == 1
     assert [label.toPlainText() for label in plot_item._hover_y_labels._labels] == ["1.000", "0.250", "0.600"]
     assert [label.color for label in plot_item._hover_y_labels._labels] == [
         QColor("yellow"),
@@ -153,7 +153,7 @@ def test_snap_gui(qtbot: QtBot) -> None:
             Qt.KeyboardModifier.NoModifier,
         )
     )
-    qtbot.waitUntil(lambda: not plot_item.hover_cursor.isVisible())
+    qtbot.waitUntil(lambda: not plot_item._hover_cursor.isVisible())
 
 
 def test_range_gui(qtbot: QtBot) -> None:

--- a/tests/test_plot_cursors.py
+++ b/tests/test_plot_cursors.py
@@ -115,8 +115,8 @@ def test_snap_gui(qtbot: QtBot) -> None:
     qtbot.waitUntil(lambda: plot_item._hover_target.isVisible())
     assert plot_item._hover_target.pos() == QPointF(0.1, 1)
     assert not_none(plot_item.hover_snap_point.snap_pos) == QPointF(0.1, 1)
-    assert [label.color for label in plot_item._hover_y_labels] == [QColor("yellow")]
-    assert [label.toPlainText() for label in plot_item._hover_y_labels] == ["1.000"]  # single label only
+    assert [label.color for label in plot_item._hover_y_labels._labels] == [QColor("yellow")]
+    assert [label.toPlainText() for label in plot_item._hover_y_labels._labels] == ["1.000"]  # single label only
 
     # disambiguate on target with shared x axis
     qtbot.wait(10)  # pyqtgraph rate-limits, so add a wait
@@ -134,8 +134,12 @@ def test_snap_gui(qtbot: QtBot) -> None:
     assert plot_item._hover_target.pos() == QPointF(1, 0.25)
     assert not_none(plot_item.hover_snap_point.snap_pos) == QPointF(1, 0.25)
     assert plot_item.hover_cursor.pos().x() == 1
-    assert [label.toPlainText() for label in plot_item._hover_y_labels] == ["1.000", "0.250", "0.600"]
-    assert [label.color for label in plot_item._hover_y_labels] == [QColor("yellow"), QColor("orange"), QColor("blue")]
+    assert [label.toPlainText() for label in plot_item._hover_y_labels._labels] == ["1.000", "0.250", "0.600"]
+    assert [label.color for label in plot_item._hover_y_labels._labels] == [
+        QColor("yellow"),
+        QColor("orange"),
+        QColor("blue"),
+    ]
 
     # off screen, cursor should disappear
     qtbot.wait(10)


### PR DESCRIPTION
For live cursors and PoIs across the timeseries and X-Y plots, reuse the scatter plot and text items for efficiency. This provides a minor performance gain for complicated setups, shaving off milliseconds.

Adds an infrastructure TextItemCollection class to manage and re-use TextItems, and a similar one for ScatterPlotItem. These also encapsulate some common operations.

Also re-use some non-interactable visual items, hiding them instead of deleting / recreating them. Rough philosophy is that interactable items still use Optional[...] with deletion / re-creation as an indicator of when those are present / active.

Other changes
- cleans up XY plot _update to only clear out its known curves, not all data items.