### PR TITLE
Bugfix for color picker on load-config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pyqtgraph-scope-plots"
 description = "Scope like plot utilities for pyqtgraph"
 readme = "README.md"
-version = "1.6.0"
+version = "1.6.1"
 authors = [
     { name = "Richard Lin", email = "richardlin@enphaseenergy.com" }
 ]

--- a/pyqtgraph_scope_plots/color_signals_table.py
+++ b/pyqtgraph_scope_plots/color_signals_table.py
@@ -28,6 +28,8 @@ class ColorPickerDataStateModel(DataTopModel):
 
 
 class ColorPickerPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
+    """Provides an API to set the color on signals, which overrides the color from show_data_items."""
+
     _DATA_MODEL_BASES = [ColorPickerDataStateModel]
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/pyqtgraph_scope_plots/color_signals_table.py
+++ b/pyqtgraph_scope_plots/color_signals_table.py
@@ -71,7 +71,10 @@ class ColorPickerPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
             self._colors[data_name] = color
         if update:
             self.show_data_items(
-                [(data_item_name, color, plot_type) for data_item_name, (color, plot_type) in self._data_items.items()]
+                [
+                    (data_item_name, data_color, plot_type)
+                    for data_item_name, (data_color, plot_type) in self._data_items.items()
+                ]
             )
             self._update_plots()
             self.sigDataItemsUpdated.emit()

--- a/pyqtgraph_scope_plots/color_signals_table.py
+++ b/pyqtgraph_scope_plots/color_signals_table.py
@@ -53,27 +53,26 @@ class ColorPickerPlotWidget(MultiPlotWidget, HasSaveLoadDataConfig):
             if data_model.color is not None:
                 self.set_colors([data_name], QColor(data_model.color), update=False)
 
-    def _update_data_item_colors(
-        self, data_items: List[Tuple[str, QColor, MultiPlotWidget.PlotType]]
-    ) -> List[Tuple[str, QColor, MultiPlotWidget.PlotType]]:
-        # transforms data items to reflect the color settings
-        new_data_items = []
-        for data_item_name, color, plot_type in data_items:
-            changed_color = self._colors.get(data_item_name, None)
-            if changed_color is not None:
-                color = changed_color
-            new_data_items.append((data_item_name, color, plot_type))
-        return new_data_items
-
     def show_data_items(
         self, new_data_items: List[Tuple[str, QColor, MultiPlotWidget.PlotType]], **kwargs: Any
     ) -> None:
-        super().show_data_items(self._update_data_item_colors(new_data_items), **kwargs)
+        # transforms data items to reflect the color settings
+        colored_new_data_items = []
+        for data_item_name, color, plot_type in new_data_items:
+            changed_color = self._colors.get(data_item_name, None)
+            if changed_color is not None:
+                color = changed_color
+            colored_new_data_items.append((data_item_name, color, plot_type))
+
+        super().show_data_items(colored_new_data_items, **kwargs)
 
     def set_colors(self, data_names: List[str], color: QColor, update: bool = True) -> None:
         for data_name in data_names:
             self._colors[data_name] = color
         if update:
+            self.show_data_items(
+                [(data_item_name, color, plot_type) for data_item_name, (color, plot_type) in self._data_items.items()]
+            )
             self._update_plots()
             self.sigDataItemsUpdated.emit()
 

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -13,10 +13,12 @@
 #    limitations under the License.
 
 from typing import cast
+from unittest import mock
 
 import pytest
 from PySide6.QtGui import Qt, QPen, QColor
 import pyqtgraph as pg
+from PySide6.QtWidgets import QColorDialog
 from pytestqt.qtbot import QtBot
 
 from pyqtgraph_scope_plots import (
@@ -47,25 +49,35 @@ def color_of_curve(curve: pg.PlotCurveItem) -> QColor:
 
 
 def test_color(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
-    color_plots.set_colors(["1"], QColor("pink"))
-    assert color_of_curve(color_plots._data_name_to_plot_item["1"]._data_graphics["1"][0]) == QColor("pink")
+    color_plots.set_colors(["1"], QColor("indigo"))
+    assert color_of_curve(color_plots._data_name_to_plot_item["1"]._data_graphics["1"][0]) == QColor("indigo")
 
     # rest should not have changed
     assert color_of_curve(color_plots._data_name_to_plot_item["0"]._data_graphics["0"][0]) == QColor("yellow")
     assert color_of_curve(color_plots._data_name_to_plot_item["2"]._data_graphics["2"][0]) == QColor("blue")
 
 
-def test_visibility_table(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
-    # TODO
-    pass
+def test_color_table(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
+    color_table = ColorPickerSignalsTable(color_plots)
+
+    # test API => table
+    color_plots.set_colors(["1"], QColor("goldenrod"))
+    assert color_table.item(1, 0).foreground().color() == QColor("goldenrod")
+
+    # test table UI => table
+    with mock.patch.object(QColorDialog, "getColor", QColor("lavender")):
+        color_table.selectRow(1)
+        color_table._on_set_color()
+    assert color_of_curve(color_plots._data_name_to_plot_item["1"]._data_graphics["1"][0]) == QColor("lavender")
+    assert color_table.item(1, 0).foreground().color() == QColor("lavender")
 
 
-def test_visibility_save(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
+def test_color_save(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
     # TODO
     model = color_plots._dump_data_model(["0", "1", "2"])
 
 
-def test_visibility_load(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
+def test_color_load(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
     # TODO
     color_table = ColorPickerSignalsTable(color_plots)
     model = color_plots._dump_data_model(["0", "1", "2"])

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -73,16 +73,21 @@ def test_color_table(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
 
 
 def test_color_save(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
-    # TODO
+    color_plots.set_colors(["1"], QColor("goldenrod"))
     model = color_plots._dump_data_model(["0", "1", "2"])
+
+    assert cast(ColorPickerDataStateModel, model.data["0"]).color is None
+    assert cast(ColorPickerDataStateModel, model.data["1"]).color == QColor("goldenrod")
+    assert cast(ColorPickerDataStateModel, model.data["2"]).color is None
 
 
 def test_color_load(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
-    # TODO
     color_table = ColorPickerSignalsTable(color_plots)
     model = color_plots._dump_data_model(["0", "1", "2"])
-    cast(ColorPickerDataStateModel, model.data["1"]).color = "pink"
+    cast(ColorPickerDataStateModel, model.data["1"]).color = QColor("goldenrod")
 
     color_plots._load_model(model)
-    color_plots.set_data(DATA)  # trigger a curve-visibility update
+    color_plots.show_data_items(DATA_ITEMS)  # trigger a colors update
     color_table._update()  # trigger update
+    assert color_of_curve(color_plots._data_name_to_plot_item["1"]._data_graphics["1"][0]) == QColor("goldenrod")
+    assert color_table.item(1, 0).foreground().color() == QColor("goldenrod")

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -65,7 +65,7 @@ def test_color_table(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
     assert color_table.item(1, 0).foreground().color() == QColor("goldenrod")
 
     # test table UI => table
-    with mock.patch.object(QColorDialog, "getColor", QColor("lavender")):
+    with mock.patch.object(QColorDialog, "getColor", lambda: QColor("lavender")):
         color_table.selectRow(1)
         color_table._on_set_color()
     assert color_of_curve(color_plots._data_name_to_plot_item["1"]._data_graphics["1"][0]) == QColor("lavender")

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -77,14 +77,14 @@ def test_color_save(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
     model = color_plots._dump_data_model(["0", "1", "2"])
 
     assert cast(ColorPickerDataStateModel, model.data["0"]).color is None
-    assert cast(ColorPickerDataStateModel, model.data["1"]).color == QColor("goldenrod")
+    assert cast(ColorPickerDataStateModel, model.data["1"]).color == QColor("goldenrod").name()
     assert cast(ColorPickerDataStateModel, model.data["2"]).color is None
 
 
 def test_color_load(qtbot: QtBot, color_plots: ColorPickerPlotWidget) -> None:
     color_table = ColorPickerSignalsTable(color_plots)
     model = color_plots._dump_data_model(["0", "1", "2"])
-    cast(ColorPickerDataStateModel, model.data["1"]).color = QColor("goldenrod")
+    cast(ColorPickerDataStateModel, model.data["1"]).color = QColor("goldenrod").name()
 
     color_plots._load_model(model)
     color_plots.show_data_items(DATA_ITEMS)  # trigger a colors update


### PR DESCRIPTION
Previously, load config does not set the table colors correctly for signals with a color override set. Likely because color state was not updated by the time the color table was updated. This restructures the color code to replace the data into show_data_items so everything downstream has the right data.

Also adds unit tests.