### PR TITLE
Add internal (API) color setting for XY plots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pyqtgraph-scope-plots"
 description = "Scope like plot utilities for pyqtgraph"
 readme = "README.md"
-version = "1.6.1"
+version = "1.6.2"
 authors = [
     { name = "Richard Lin", email = "richardlin@enphaseenergy.com" }
 ]

--- a/pyqtgraph_scope_plots/xy_plot_splitter.py
+++ b/pyqtgraph_scope_plots/xy_plot_splitter.py
@@ -11,10 +11,11 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-from typing import Type
+from typing import Type, Optional
 
 from PySide6 import QtGui
 from PySide6.QtCore import Qt
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QSplitter
 from pydantic import BaseModel
 
@@ -46,8 +47,8 @@ class XyPlotSplitter(BaseXyPlot, QSplitter):
         self._table = self._make_xy_plot_table()
         self.addWidget(self._table)
 
-    def add_xy(self, x_name: str, y_name: str) -> None:
-        self._xy_plots.add_xy(x_name, y_name)
+    def add_xy(self, x_name: str, y_name: str, *, color: Optional[QColor] = None) -> None:
+        self._xy_plots.add_xy(x_name, y_name, color=color)
 
     def remove_xy(self, x_name: str, y_name: str) -> None:
         self._xy_plots.remove_xy(x_name, y_name)

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -118,20 +118,25 @@ def test_xy_offset(qtbot: QtBot, xy_table: XyTable) -> None:
 
 def test_xy_save(qtbot: QtBot, xy_table: XyTable) -> None:
     xy_plot = xy_table.create_xy()
-    xy_plot.add_xy("0", "1")
+    xy_plot.add_xy("0", "1", color=QColor("lavender"))
     xy_plot.add_xy("1", "0")
     qtbot.waitUntil(lambda: len(not_none(cast(XyTableStateModel, xy_table._dump_data_model([])).xy_windows)) == 1)
     model = cast(XyTableStateModel, xy_table._dump_data_model([]))
     assert not_none(model.xy_windows)[0].xy_data_items == [("0", "1"), ("1", "0")]
+    assert not_none(model.xy_windows)[0].xy_colors == {("0", "1"): QColor("lavender").name()}
 
 
 def test_xy_load(qtbot: QtBot, xy_table: XyTable) -> None:
     model = cast(XyTableStateModel, xy_table._dump_data_model([]))
 
-    model.xy_windows = [XyWindowModel(xy_data_items=[("1", "0")])]
+    model.xy_windows = [
+        XyWindowModel(xy_data_items=[("0", "1"), ("1", "0")], xy_colors={("0", "1"): QColor("lavender").name()})
+    ]
     xy_table._load_model(model)
     qtbot.waitUntil(lambda: len(xy_table._xy_plots) == 1)
-    assert cast(XyPlotSplitter, xy_table._xy_plots[0])._xy_plots._xys == [("1", "0")]
+    assert cast(XyPlotSplitter, xy_table._xy_plots[0])._xy_plots._xys == [("0", "1"), ("1", "0")]
+    assert cast(XyPlotSplitter, xy_table._xy_plots[0])._xy_plots._color_of("0", "1") == QColor("lavender")
+    assert cast(XyPlotSplitter, xy_table._xy_plots[0])._xy_plots._color_of("1", "0") == QColor("yellow")
 
 
 def test_xy_table(qtbot: QtBot, xy_table: XyTable) -> None:

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -79,6 +79,7 @@ def test_xy_create_ui(qtbot: QtBot, xy_table: XyTable) -> None:
     qtbot.waitSignal(xy_plot._xy_plots.sigXyDataItemsChanged)
     assert xy_plot is not None
     assert xy_plot._xy_plots._xys == [("1", "0")]
+    assert xy_plot._xy_plots._color_of("1", "0") == QColor("yellow")
 
     xy_table.clearSelection()
     xy_table.item(0, 0).setSelected(True)
@@ -87,6 +88,7 @@ def test_xy_create_ui(qtbot: QtBot, xy_table: XyTable) -> None:
     qtbot.waitSignal(xy_plot._xy_plots.sigXyDataItemsChanged)
     assert xy_plot is not None
     assert xy_plot._xy_plots._xys == [("0", "1")]
+    assert xy_plot._xy_plots._color_of("0", "1") == QColor("orange")
 
     qtbot.wait(10)  # wait for rendering to happen
 
@@ -97,6 +99,12 @@ def test_xy_close_cleanup(qtbot: QtBot, xy_table: XyTable) -> None:
     qtbot.waitUntil(lambda: len(xy_table._xy_plots) > 0)
     xy_plot.close()
     qtbot.waitUntil(lambda: not xy_table._xy_plots)
+
+
+def test_xy_color(qtbot: QtBot, xy_table: XyTable) -> None:
+    xy_plot = cast(XyPlotSplitter, xy_table.create_xy())
+    xy_plot.add_xy("0", "1", color=QColor("lavender"))
+    assert xy_plot._xy_plots._color_of("0", "1") == QColor("lavender")
 
 
 def test_xy_offset(qtbot: QtBot, xy_table: XyTable) -> None:


### PR DESCRIPTION
Add optional color parameter to `add_xy`. State is properly saved to YAML, though not exposed to the GUI (yet?).

Also changes both the x and y table entries to use the same color, the color of the xy trace (instead of the source traces).