### PR TITLE
Add help text on empty plots

### DIFF
--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -36,11 +36,21 @@ from pyqtgraph_scope_plots.graphics_collections import ScatterItemCollection, Te
 class DataPlotItem(pg.PlotItem):  # type: ignore[misc]
     """Abstract base class for a PlotItem that takes some data."""
 
+    _EMPTY_PLOT_HELP_TEXT = (
+        "No data items selected for plotting.\nDrag and drop rows from the signals table to plot them.",
+    )
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._data_items: Dict[str, QColor] = {}
         self._data_graphics: Dict[str, List[pg.GraphicsObject]] = {}
         self._data: Dict[str, Tuple[npt.NDArray[np.float64], npt.NDArray[Any]]] = {}
+
+        # This is shown by default for when an empty plot is constructed without calling set_data_items
+        self._empty_plot_text = pg.TextItem(text=self._EMPTY_PLOT_HELP_TEXT, anchor=(0.5, 0.5))
+        self.addItem(self._empty_plot_text, ignoreBounds=True)
+        self._on_range_changed_for_empty_indicator()  # update position
+        self.sigRangeChanged.connect(self._on_range_changed_for_empty_indicator)
 
     def set_data_items(self, data_items: Mapping[str, QColor]) -> None:
         """Generates plot items for the input data items."""
@@ -64,6 +74,20 @@ class DataPlotItem(pg.PlotItem):  # type: ignore[misc]
             if graphics is None:  # not pre-defined in set_data_items, ignore
                 continue
             self._update_plot_data(data_name, xs, ys)
+
+        if not len(data):
+            self._on_range_changed_for_empty_indicator()
+            self._empty_plot_text.show()
+        else:
+            self._empty_plot_text.hide()
+
+    def _on_range_changed_for_empty_indicator(self) -> None:
+        """Updates the position of the empty plot indicator when the view range changes."""
+        if self._empty_plot_text.isVisible():
+            view_rect = self.viewRect()
+            center_x = view_rect.x() + view_rect.width() / 2
+            center_y = view_rect.y() + view_rect.height() / 2
+            self._empty_plot_text.setPos(center_x, center_y)
 
     @abstractmethod
     def _generate_plot_items(self, data_items: Mapping[str, QColor]) -> Dict[str, List[pg.GraphicsObject]]:

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -754,12 +754,10 @@ class EmptyPlotIndicatorPlot(SnappableHoverPlot):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-        # Create empty plot indicator (shown by default)
+        # The empty plot help text is shown by default for the default empty plot
         self._empty_plot_text = pg.TextItem(text=self._EMPTY_PLOT_HELP_TEXT, anchor=(0.5, 0.5))
         self.addItem(self._empty_plot_text, ignoreBounds=True)
         self._on_range_changed_for_empty_indicator()
-
-        # Connect to sigRangeChanged (inherited from pg.PlotItem)
         self.sigRangeChanged.connect(self._on_range_changed_for_empty_indicator)
 
     def set_data(self, data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[Any]]]) -> None:

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -36,21 +36,11 @@ from pyqtgraph_scope_plots.graphics_collections import ScatterItemCollection, Te
 class DataPlotItem(pg.PlotItem):  # type: ignore[misc]
     """Abstract base class for a PlotItem that takes some data."""
 
-    _EMPTY_PLOT_HELP_TEXT = (
-        "No data items selected for plotting.\nDrag and drop rows from the signals table to plot them."
-    )
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._data_items: Dict[str, QColor] = {}
         self._data_graphics: Dict[str, List[pg.GraphicsObject]] = {}
         self._data: Dict[str, Tuple[npt.NDArray[np.float64], npt.NDArray[Any]]] = {}
-
-        # This is shown by default for when an empty plot is constructed without calling set_data_items
-        self._empty_plot_text = pg.TextItem(text=self._EMPTY_PLOT_HELP_TEXT, anchor=(0.5, 0.5))
-        self.addItem(self._empty_plot_text, ignoreBounds=True)
-        self._on_range_changed_for_empty_indicator()  # update position
-        self.sigRangeChanged.connect(self._on_range_changed_for_empty_indicator)
 
     def set_data_items(self, data_items: Mapping[str, QColor]) -> None:
         """Generates plot items for the input data items."""
@@ -74,20 +64,6 @@ class DataPlotItem(pg.PlotItem):  # type: ignore[misc]
             if graphics is None:  # not pre-defined in set_data_items, ignore
                 continue
             self._update_plot_data(data_name, xs, ys)
-
-        if not len(data):
-            self._on_range_changed_for_empty_indicator()
-            self._empty_plot_text.show()
-        else:
-            self._empty_plot_text.hide()
-
-    def _on_range_changed_for_empty_indicator(self) -> None:
-        """Updates the position of the empty plot indicator when the view range changes."""
-        if self._empty_plot_text.isVisible():
-            view_rect = self.viewRect()
-            center_x = view_rect.x() + view_rect.width() / 2
-            center_y = view_rect.y() + view_rect.height() / 2
-            self._empty_plot_text.setPos(center_x, center_y)
 
     @abstractmethod
     def _generate_plot_items(self, data_items: Mapping[str, QColor]) -> Dict[str, List[pg.GraphicsObject]]:
@@ -762,3 +738,44 @@ class DraggableCursorPlot(SnappableHoverPlot, HasDataValueAt):
             self.set_drag_cursor(None)
         elif ev.key() == Qt.Key.Key_Delete:
             self.set_drag_cursor(None)
+
+
+class EmptyPlotIndicatorPlot(SnappableHoverPlot):
+    """Mixin that adds an empty plot indicator when no data is present.
+    The indicator is shown by default and hidden when data is added
+
+    Although this could be directly a mixin on PlotItem, it is placed here
+    to avoid signal/slot ordering warnings."""
+
+    _EMPTY_PLOT_HELP_TEXT = (
+        "No data items selected for plotting.\nDrag and drop rows from the signals table to plot them."
+    )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        # Create empty plot indicator (shown by default)
+        self._empty_plot_text = pg.TextItem(text=self._EMPTY_PLOT_HELP_TEXT, anchor=(0.5, 0.5))
+        self.addItem(self._empty_plot_text, ignoreBounds=True)
+        self._on_range_changed_for_empty_indicator()
+
+        # Connect to sigRangeChanged (inherited from pg.PlotItem)
+        self.sigRangeChanged.connect(self._on_range_changed_for_empty_indicator)
+
+    def set_data(self, data: Mapping[str, Tuple[npt.NDArray[np.float64], npt.NDArray[Any]]]) -> None:
+        """Override to show/hide empty plot indicator based on data presence."""
+        super().set_data(data)
+
+        if not len(data):
+            self._on_range_changed_for_empty_indicator()
+            self._empty_plot_text.show()
+        else:
+            self._empty_plot_text.hide()
+
+    def _on_range_changed_for_empty_indicator(self) -> None:
+        """Updates the position of the empty plot indicator when the view range changes."""
+        if self._empty_plot_text.isVisible():
+            view_rect = self.viewRect()
+            center_x = view_rect.x() + view_rect.width() / 2
+            center_y = view_rect.y() + view_rect.height() / 2
+            self._empty_plot_text.setPos(center_x, center_y)

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -37,7 +37,7 @@ class DataPlotItem(pg.PlotItem):  # type: ignore[misc]
     """Abstract base class for a PlotItem that takes some data."""
 
     _EMPTY_PLOT_HELP_TEXT = (
-        "No data items selected for plotting.\nDrag and drop rows from the signals table to plot them.",
+        "No data items selected for plotting.\nDrag and drop rows from the signals table to plot them."
     )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/pyqtgraph_scope_plots/interactivity_mixins.py
+++ b/pyqtgraph_scope_plots/interactivity_mixins.py
@@ -741,11 +741,9 @@ class DraggableCursorPlot(SnappableHoverPlot, HasDataValueAt):
 
 
 class EmptyPlotIndicatorPlot(SnappableHoverPlot):
-    """Mixin that adds an empty plot indicator when no data is present.
-    The indicator is shown by default and hidden when data is added
+    """Mixin that adds an empty plot indicator when no data is selected for plotting.
 
-    Although this could be directly a mixin on PlotItem, it is placed here
-    to avoid signal/slot ordering warnings."""
+    Although this could be directly a mixin on PlotItem, it is placed here to avoid signal/slot ordering warnings."""
 
     _EMPTY_PLOT_HELP_TEXT = (
         "No data items selected for plotting.\nDrag and drop rows from the signals table to plot them."
@@ -770,6 +768,7 @@ class EmptyPlotIndicatorPlot(SnappableHoverPlot):
         else:
             self._empty_plot_text.hide()
 
+    @Slot()
     def _on_range_changed_for_empty_indicator(self) -> None:
         """Updates the position of the empty plot indicator when the view range changes."""
         if self._empty_plot_text.isVisible():

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -33,6 +33,7 @@ from .interactivity_mixins import (
     DataPlotCurveItem,
     DataPlotItem,
     NudgeablePlot,
+    EmptyPlotIndicatorPlot,
 )
 from .point_on_zoom_plot import PointOnZoomPlot, EnumPointOnZoomPlot
 from .util import BaseTopModel, HasSaveLoadDataConfig
@@ -45,6 +46,7 @@ class InteractivePlot(
     RegionPlot,
     LiveCursorPlot,
     PointOnZoomPlot,
+    EmptyPlotIndicatorPlot,
     DataPlotCurveItem,
 ):
     """PlotItem with interactivity mixins"""
@@ -57,6 +59,7 @@ class EnumWaveformInteractivePlot(
     RegionPlot,
     LiveCursorPlot,
     EnumPointOnZoomPlot,
+    EmptyPlotIndicatorPlot,
     EnumWaveformPlot,
 ):
     """Enum plot with all the interactivity mixins"""

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -165,18 +165,11 @@ def test_no_excessive_plots(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 def test_export_csv(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     out_io = StringIO()
     plot._write_csv(out_io)
-    assert (
-        out_io.getvalue().replace("\r", "").replace("\n", "")
-        == """# time,0,1,2
+    assert out_io.getvalue().replace("\r", "").replace("\n", "") == """# time,0,1,2
 0.0,0.01,0.5,0.7
 0.1,1.0,,
 1.0,1.0,0.25,0.6
-2.0,0.0,0.5,0.5""".replace(
-            "\r", ""
-        ).replace(
-            "\n", ""
-        )
-    )  # ignore newline format
+2.0,0.0,0.5,0.5""".replace("\r", "").replace("\n", "")  # ignore newline format
 
     plot._set_data(
         {  # more comprehensive missing data test
@@ -187,17 +180,10 @@ def test_export_csv(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     )
     out_io = StringIO()
     plot._write_csv(out_io)
-    assert (
-        out_io.getvalue().replace("\r", "").replace("\n", "")
-        == """# time,0,1,2
+    assert out_io.getvalue().replace("\r", "").replace("\n", "") == """# time,0,1,2
 0.0,0.01,0.25,
 1.0,,0.5,0.7
-2.0,0.0,,0.6""".replace(
-            "\r", ""
-        ).replace(
-            "\n", ""
-        )
-    )  # ignore newline format
+2.0,0.0,,0.6""".replace("\r", "").replace("\n", "")  # ignore newline format
 
 
 def test_empty_plot_indicator(qtbot: QtBot) -> None:

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -202,7 +202,7 @@ def test_export_csv(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 
 def test_empty_plot_indicator(qtbot: QtBot) -> None:
     """Test that empty plot indicator is shown when appropriate."""
-    from pyqtgraph_scope_plots.interactivity_mixins import DataPlotItem
+    from pyqtgraph_scope_plots.interactivity_mixins import EmptyPlotIndicatorPlot
 
     plot = PlotsTableWidget()
     qtbot.addWidget(plot)
@@ -211,7 +211,7 @@ def test_empty_plot_indicator(qtbot: QtBot) -> None:
 
     # Initially, plot should have the empty indicator visible (no data items set)
     qtbot.waitUntil(lambda: plot._plots.count() == 1)
-    plot_item = cast(DataPlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem())
+    plot_item = cast(EmptyPlotIndicatorPlot, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem())
     assert plot_item._empty_plot_text.isVisible()
 
     # Add data items and data - indicator should be hidden
@@ -219,11 +219,11 @@ def test_empty_plot_indicator(qtbot: QtBot) -> None:
     plot._set_data(DATA)
     qtbot.waitUntil(lambda: plot._plots.count() == 3)
     # update the plot item since they may be re-created on data update
-    plot_item = cast(DataPlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem())
+    plot_item = cast(EmptyPlotIndicatorPlot, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem())
     qtbot.waitUntil(lambda: not plot_item._empty_plot_text.isVisible())
 
     # Remove all data - indicator should be shown again
     plot._set_data_items([])
     qtbot.waitUntil(lambda: plot._plots.count() == 1)
-    plot_item = cast(DataPlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem())
+    plot_item = cast(EmptyPlotIndicatorPlot, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem())
     qtbot.waitUntil(lambda: plot_item._empty_plot_text.isVisible())

--- a/tests/test_base_plot.py
+++ b/tests/test_base_plot.py
@@ -165,11 +165,18 @@ def test_no_excessive_plots(qtbot: QtBot, plot: PlotsTableWidget) -> None:
 def test_export_csv(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     out_io = StringIO()
     plot._write_csv(out_io)
-    assert out_io.getvalue().replace("\r", "").replace("\n", "") == """# time,0,1,2
+    assert (
+        out_io.getvalue().replace("\r", "").replace("\n", "")
+        == """# time,0,1,2
 0.0,0.01,0.5,0.7
 0.1,1.0,,
 1.0,1.0,0.25,0.6
-2.0,0.0,0.5,0.5""".replace("\r", "").replace("\n", "")  # ignore newline format
+2.0,0.0,0.5,0.5""".replace(
+            "\r", ""
+        ).replace(
+            "\n", ""
+        )
+    )  # ignore newline format
 
     plot._set_data(
         {  # more comprehensive missing data test
@@ -180,7 +187,43 @@ def test_export_csv(qtbot: QtBot, plot: PlotsTableWidget) -> None:
     )
     out_io = StringIO()
     plot._write_csv(out_io)
-    assert out_io.getvalue().replace("\r", "").replace("\n", "") == """# time,0,1,2
+    assert (
+        out_io.getvalue().replace("\r", "").replace("\n", "")
+        == """# time,0,1,2
 0.0,0.01,0.25,
 1.0,,0.5,0.7
-2.0,0.0,,0.6""".replace("\r", "").replace("\n", "")  # ignore newline format
+2.0,0.0,,0.6""".replace(
+            "\r", ""
+        ).replace(
+            "\n", ""
+        )
+    )  # ignore newline format
+
+
+def test_empty_plot_indicator(qtbot: QtBot) -> None:
+    """Test that empty plot indicator is shown when appropriate."""
+    from pyqtgraph_scope_plots.interactivity_mixins import DataPlotItem
+
+    plot = PlotsTableWidget()
+    qtbot.addWidget(plot)
+    plot.show()
+    qtbot.waitExposed(plot)
+
+    # Initially, plot should have the empty indicator visible (no data items set)
+    qtbot.waitUntil(lambda: plot._plots.count() == 1)
+    plot_item = cast(DataPlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem())
+    assert plot_item._empty_plot_text.isVisible()
+
+    # Add data items and data - indicator should be hidden
+    plot._set_data_items(DATA_ITEMS)
+    plot._set_data(DATA)
+    qtbot.waitUntil(lambda: plot._plots.count() == 3)
+    # update the plot item since they may be re-created on data update
+    plot_item = cast(DataPlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem())
+    qtbot.waitUntil(lambda: not plot_item._empty_plot_text.isVisible())
+
+    # Remove all data - indicator should be shown again
+    plot._set_data_items([])
+    qtbot.waitUntil(lambda: plot._plots.count() == 1)
+    plot_item = cast(DataPlotItem, cast(pg.PlotWidget, plot._plots.widget(0)).getPlotItem())
+    qtbot.waitUntil(lambda: plot_item._empty_plot_text.isVisible())


### PR DESCRIPTION
Makes it more obvious that there is no data selected for plotting, as opposed to the data being empty / bad / bugged.

Unfortunately the signal / slot ordering requirement makes the inheritance ordering less elegant than it should be.