### PR TITLE
Add API to programmatically control plot overlays

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pyqtgraph-scope-plots"
 description = "Scope like plot utilities for pyqtgraph"
 readme = "README.md"
-version = "1.6.4"
+version = "1.6.5"
 authors = [
     { name = "Richard Lin", email = "richardlin@enphaseenergy.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pyqtgraph~=0.13",
     "pillow>=9.0",
     "pandas~=2.0",
-    "numpy>=1.19,<2.5",  # numpy 2.5 requires Python 3.12
+    "numpy>=1.19",
     "pydantic>=2.0",
     "simpleeval>=1.0",
     "PyYAML>=6.0",
@@ -59,7 +59,6 @@ profile = "black"
 plugins = [
     "pydantic.mypy"
 ]
-python_version = "3.10"  # pytest uses 3.10 syntax internally
 check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true
@@ -68,7 +67,6 @@ strict = true
 [[tool.mypy.overrides]]
 module = ["pyqtgraph.*", "simpleeval.*", "pytestqt.*"]
 ignore_missing_imports = true
-
 
 [[tool.mypy.overrides]]
 module = ["tests.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pyqtgraph~=0.13",
     "pillow>=9.0",
     "pandas~=2.0",
-    "numpy>=1.19",
+    "numpy>=1.19,<2.5",  # numpy 2.5 requires Python 3.12
     "pydantic>=2.0",
     "simpleeval>=1.0",
     "PyYAML>=6.0",
@@ -69,9 +69,6 @@ strict = true
 module = ["pyqtgraph.*", "simpleeval.*", "pytestqt.*"]
 ignore_missing_imports = true
 
-[[tool.mypy.overrides]]
-module = ["numpy.*"]
-follow_imports = "silent"
 
 [[tool.mypy.overrides]]
 module = ["tests.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,10 @@ module = ["pyqtgraph.*", "simpleeval.*", "pytestqt.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = ["numpy.*"]
+follow_imports = "silent"
+
+[[tool.mypy.overrides]]
 module = ["tests.*"]
 disable_error_code = ["union-attr", "no-untyped-call"]
 

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -291,7 +291,7 @@ class MultiPlotWidget(HasSaveLoadDataConfig, QSplitter):
             is_first = False
 
     def _merge_data_into_item(self, source_data_names: List[str], target_plot_index: int, insert: bool = False) -> None:
-        """Merges a data (by name) into a target PlotItem, overlaying both on the same plot"""
+        """Merges data (by name) into a target PlotItem, overlaying both on the same plot"""
         if len(source_data_names) == 0:  # nothing to be done
             return
 

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -306,8 +306,8 @@ class MultiPlotWidget(HasSaveLoadDataConfig, QSplitter):
             for source_data_name in source_data_names:
                 if len(self._plot_item_data[target_plot_item]) > 0:  # check for merge-ability, for nonempty plots
                     if (
-                            self._data_items[self._plot_item_data[target_plot_item][0] or ""][1]
-                            != self._data_items[source_data_name][1]
+                        self._data_items[self._plot_item_data[target_plot_item][0] or ""][1]
+                        != self._data_items[source_data_name][1]
                     ):
                         continue
                 self._plot_item_data[target_plot_item].append(source_data_name)

--- a/pyqtgraph_scope_plots/multi_plot_widget.py
+++ b/pyqtgraph_scope_plots/multi_plot_widget.py
@@ -290,6 +290,76 @@ class MultiPlotWidget(HasSaveLoadDataConfig, QSplitter):
 
             is_first = False
 
+    def _merge_data_into_item(self, source_data_names: List[str], target_plot_index: int, insert: bool = False) -> None:
+        """Merges a data (by name) into a target PlotItem, overlaying both on the same plot"""
+        if len(source_data_names) == 0:  # nothing to be done
+            return
+
+        created_data_names = []  # list of data names that were successfully created / moved
+        if not insert:  # merge mode
+            target_plot_widget = self.widget(target_plot_index)
+            if not isinstance(target_plot_widget, pg.PlotWidget):
+                return
+            target_plot_item = target_plot_widget.getPlotItem()
+            if isinstance(target_plot_item, EnumWaveformPlot):  # can't merge into enum plots
+                return
+            for source_data_name in source_data_names:
+                if len(self._plot_item_data[target_plot_item]) > 0:  # check for merge-ability, for nonempty plots
+                    if (
+                            self._data_items[self._plot_item_data[target_plot_item][0] or ""][1]
+                            != self._data_items[source_data_name][1]
+                    ):
+                        continue
+                self._plot_item_data[target_plot_item].append(source_data_name)
+                created_data_names.append(source_data_name)
+        else:  # create-new-graph-and-insert mode
+            plot_item = self._init_plot_item(self._create_plot_item(self._data_items[source_data_names[0]][1]))
+            if self._anchor_x_plot_item is not None:
+                plot_item.setXLink(self._anchor_x_plot_item)
+            else:
+                self._anchor_x_plot_item = plot_item
+            plot_widget = pg.PlotWidget(plotItem=plot_item)
+            self.insertWidget(target_plot_index, plot_widget)
+
+            self._plot_item_data[plot_item] = [source_data_names[0]]
+            created_data_names.append(source_data_names[0])
+
+            if isinstance(plot_item, EnumWaveformPlot):  # only one data item
+                pass
+            else:  # append all compatible
+                for source_data_name in source_data_names[1:]:
+                    if self._data_items[source_data_names[0]][1] != self._data_items[source_data_name][1]:
+                        continue
+                    self._plot_item_data[plot_item].append(source_data_name)
+                    created_data_names.append(source_data_name)
+
+            self._update_plots_x_axis()
+
+        for created_data_name in created_data_names:
+            created_item = self._data_name_to_plot_item.get(created_data_name)
+            if created_item is not None:  # delete source
+                self._plot_item_data[created_item].remove(created_data_name)
+                if not len(self._plot_item_data[created_item]):
+                    self._clean_plot_widgets()
+                    self._update_plots_x_axis()
+
+        self._update_plot_item_data_items()
+        self._update_plots()
+
+    def merge_data_items(self, source: str, target: str) -> None:
+        """Overlay *source* onto the same panel as *target*, by data name.
+        Source and target must exist and be visible, otherwise this asserts out.
+        """
+        source_plot_item = self._data_name_to_plot_item.get(source)
+        target_plot_item = self._data_name_to_plot_item.get(target)
+        assert source_plot_item is not None and target_plot_item is not None
+
+        for i in range(self.count()):
+            widget = self.widget(i)
+            if isinstance(widget, pg.PlotWidget) and widget.getPlotItem() is target_plot_item:
+                self._merge_data_into_item([source], i, insert=False)
+                return
+
     def remove_plot_items(self, remove_data_names: List[str]) -> None:
         for plot_item, data_names in self._plot_item_data.items():
             self._plot_item_data[plot_item] = list(filter(lambda x: x not in remove_data_names, data_names))
@@ -526,62 +596,6 @@ class DroppableMultiPlotWidget(MultiPlotWidget):
         self._drag_target: Optional[Tuple[int, bool]] = None  # insertion index, insertion (True) or overlay (False)
         self._drag_overlays: List[DragTargetOverlay] = []
         self.setAcceptDrops(True)
-
-    def _merge_data_into_item(self, source_data_names: List[str], target_plot_index: int, insert: bool = False) -> None:
-        """Merges a data (by name) into a target PlotItem, overlaying both on the same plot"""
-        if len(source_data_names) == 0:  # notihng to be done
-            return
-
-        created_data_names = []  # list of data names that were successfully created / moved
-        if not insert:  # merge mode
-            target_plot_widget = self.widget(target_plot_index)
-            if not isinstance(target_plot_widget, pg.PlotWidget):
-                return
-            target_plot_item = target_plot_widget.getPlotItem()
-            if isinstance(target_plot_item, EnumWaveformPlot):  # can't merge into enum plots
-                return
-            for source_data_name in source_data_names:
-                if len(self._plot_item_data[target_plot_item]) > 0:  # check for merge-ability, for nonempty plots
-                    if (
-                        self._data_items[self._plot_item_data[target_plot_item][0] or ""][1]
-                        != self._data_items[source_data_name][1]
-                    ):
-                        continue
-                self._plot_item_data[target_plot_item].append(source_data_name)
-                created_data_names.append(source_data_name)
-        else:  # create-new-graph-and-insert mode
-            plot_item = self._init_plot_item(self._create_plot_item(self._data_items[source_data_names[0]][1]))
-            if self._anchor_x_plot_item is not None:
-                plot_item.setXLink(self._anchor_x_plot_item)
-            else:
-                self._anchor_x_plot_item = plot_item
-            plot_widget = pg.PlotWidget(plotItem=plot_item)
-            self.insertWidget(target_plot_index, plot_widget)
-
-            self._plot_item_data[plot_item] = [source_data_names[0]]
-            created_data_names.append(source_data_names[0])
-
-            if isinstance(plot_item, EnumWaveformPlot):  # only one data item
-                pass
-            else:  # append all compatible
-                for source_data_name in source_data_names[1:]:
-                    if self._data_items[source_data_names[0]][1] != self._data_items[source_data_name][1]:
-                        continue
-                    self._plot_item_data[plot_item].append(source_data_name)
-                    created_data_names.append(source_data_name)
-
-            self._update_plots_x_axis()
-
-        for created_data_name in created_data_names:
-            created_item = self._data_name_to_plot_item.get(created_data_name)
-            if created_item is not None:  # delete source
-                self._plot_item_data[created_item].remove(created_data_name)
-                if not len(self._plot_item_data[created_item]):
-                    self._clean_plot_widgets()
-                    self._update_plots_x_axis()
-
-        self._update_plot_item_data_items()
-        self._update_plots()
 
     def dragEnterEvent(self, event: QDragMoveEvent) -> None:
         from .signals_table import DraggableSignalsTable


### PR DESCRIPTION
Moves `_merge_data_into_item` into base MultiPlotWidget and provides a public name-based API.

Also bumps version.

Fixes project metadata to drop the python_version from mypy, since numpy 2.5 requires Python 3.12.